### PR TITLE
Switching from requests to aiohttp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Authentication via credentials or tokens is supported, Two-Factor-Authentication
 Dependencies
 ------------
 * Python >= 3.5
-* Libraries: requests, demjson, appdirs, urwid
+* Libraries: aiohttp, demjson, appdirs, urwid
 
 How to use
 ----------

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     test_suite="tests",
     install_requires=[
-        'requests',
+        'aiohttp',
         'demjson',
         'appdirs',
         'urwid'

--- a/xbox/webapi/api/provider/account.py
+++ b/xbox/webapi/api/provider/account.py
@@ -8,7 +8,7 @@ class AccountProvider(BaseProvider):
     HEADERS_USER_MGT = {'x-xbl-contract-version': '1'}
     HEADERS_ACCOUNT = {'x-xbl-contract-version': '2'}
 
-    def claim_gamertag(self, xuid, gamertag):
+    async def claim_gamertag(self, xuid, gamertag):
         """
         Claim gamertag
 
@@ -24,17 +24,17 @@ class AccountProvider(BaseProvider):
             gamertag (str): Desired gamertag
 
         Returns:
-            object: Instance of :class:`requests.Response`
+            object: Instance of :class:`aiohttp.ClientResponse`
         """
         url = self.BASE_URL_USER_MGT + "/gamertags/reserve"
         post_data = {
             "Gamertag": gamertag,
             "ReservationId": str(xuid)
         }
-        return self.client.session.post(url, json=post_data,
+        return await self.client.session.post(url, json=post_data,
                                         headers=self.HEADERS_USER_MGT)
 
-    def change_gamertag(self, xuid, gamertag, preview=False):
+    async def change_gamertag(self, xuid, gamertag, preview=False):
         """
         Change your gamertag.
 
@@ -48,7 +48,7 @@ class AccountProvider(BaseProvider):
             preview (bool): Preview the change
 
         Returns:
-            object: Instance of :class:`requests.Response`
+            object: Instance of :class:`aiohttp.ClientResponse`
         """
         url = self.BASE_URL_ACCOUNT + "/users/current/profile/gamertag"
         post_data = {
@@ -56,5 +56,5 @@ class AccountProvider(BaseProvider):
             "preview": preview,
             "reservationId": int(xuid)
         }
-        return self.client.session.post(url, json=post_data,
+        return await self.client.session.post(url, json=post_data,
                                         headers=self.HEADERS_ACCOUNT)

--- a/xbox/webapi/api/provider/achievements.py
+++ b/xbox/webapi/api/provider/achievements.py
@@ -11,7 +11,7 @@ class AchievementsProvider(BaseProvider):
     HEADERS_GAME_360_PROGRESS = {'x-xbl-contract-version': '1'}
     HEADERS_GAME_PROGRESS = {'x-xbl-contract-version': '2'}
 
-    def get_achievements_detail_item(self, xuid, service_config_id, achievement_id):
+    async def get_achievements_detail_item(self, xuid, service_config_id, achievement_id):
         """
         Get achievement detail for specific item
 
@@ -21,12 +21,12 @@ class AchievementsProvider(BaseProvider):
             achievement_id (str): Achievement Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.ACHIEVEMENTS_URL + "/users/xuid(%s)/achievements/%s/%s" % (xuid, service_config_id, achievement_id)
-        return self.client.session.get(url, headers=self.HEADERS_GAME_PROGRESS)
+        return await self.client.session.get(url, headers=self.HEADERS_GAME_PROGRESS)
 
-    def get_achievements_xbox360_all(self, xuid, title_id):
+    async def get_achievements_xbox360_all(self, xuid, title_id):
         """
         Get all achievements for specific X360 title Id
 
@@ -35,15 +35,15 @@ class AchievementsProvider(BaseProvider):
             title_id (str): Xbox 360 Title Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.ACHIEVEMENTS_URL + "/users/xuid(%s)/titleachievements?" % xuid
         params = {
             "titleId": title_id
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAME_360_PROGRESS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAME_360_PROGRESS)
 
-    def get_achievements_xbox360_earned(self, xuid, title_id):
+    async def get_achievements_xbox360_earned(self, xuid, title_id):
         """
         Get earned achievements for specific X360 title id
 
@@ -52,15 +52,15 @@ class AchievementsProvider(BaseProvider):
             title_id (str): Xbox 360 Title Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.ACHIEVEMENTS_URL + "/users/xuid(%s)/achievements?" % xuid
         params = {
             "titleId": title_id
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAME_360_PROGRESS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAME_360_PROGRESS)
 
-    def get_achievements_xbox360_recent_progress_and_info(self, xuid):
+    async def get_achievements_xbox360_recent_progress_and_info(self, xuid):
         """
         Get recent achievement progress and information
 
@@ -68,12 +68,12 @@ class AchievementsProvider(BaseProvider):
             xuid (str): Xbox User Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.ACHIEVEMENTS_URL + "/users/xuid(%s)/history/titles" % xuid
-        return self.client.session.get(url, headers=self.HEADERS_GAME_360_PROGRESS)
+        return await self.client.session.get(url, headers=self.HEADERS_GAME_360_PROGRESS)
 
-    def get_achievements_xboxone_gameprogress(self, xuid, title_id):
+    async def get_achievements_xboxone_gameprogress(self, xuid, title_id):
         """
         Get gameprogress for Xbox One title
 
@@ -82,15 +82,15 @@ class AchievementsProvider(BaseProvider):
             title_id (str): Xbox One Title Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.ACHIEVEMENTS_URL + "/users/xuid(%s)/achievements?" % xuid
         params = {
             "titleId": title_id
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAME_PROGRESS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAME_PROGRESS)
 
-    def get_achievements_xboxone_recent_progress_and_info(self, xuid):
+    async def get_achievements_xboxone_recent_progress_and_info(self, xuid):
         """
         Get recent achievement progress and information
 
@@ -98,7 +98,7 @@ class AchievementsProvider(BaseProvider):
             xuid (str): Xbox User Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.ACHIEVEMENTS_URL + "/users/xuid(%s)/history/titles" % xuid
-        return self.client.session.get(url, headers=self.HEADERS_GAME_PROGRESS)
+        return await self.client.session.get(url, headers=self.HEADERS_GAME_PROGRESS)

--- a/xbox/webapi/api/provider/cqs.py
+++ b/xbox/webapi/api/provider/cqs.py
@@ -21,7 +21,7 @@ class CQSProvider(BaseProvider):
         'x-xbl-isautomated-client': 'true'
     }
 
-    def get_channel_list(self, locale_info, headend_id):
+    async def get_channel_list(self, locale_info, headend_id):
         """
         Get stump channel list
 
@@ -30,15 +30,15 @@ class CQSProvider(BaseProvider):
             headend_id (str): Headend id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.CQS_URL + "/epg/%s/lineups/%s/channels?" % (locale_info, headend_id)
         params = {
             "desired": str(VesperType.MOBILE_LINEUP)
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_CQS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_CQS)
 
-    def get_schedule(self, locale_info, headend_id, start_date, duration_minutes, channel_skip, channel_count):
+    async def get_schedule(self, locale_info, headend_id, start_date, duration_minutes, channel_skip, channel_count):
         """
         Get stump epg data
 
@@ -51,7 +51,7 @@ class CQSProvider(BaseProvider):
             channel_count (int): Count of channels to get data for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.CQS_URL + "/epg/%s/lineups/%s/programs?" % (locale_info, headend_id)
         params = {
@@ -61,7 +61,7 @@ class CQSProvider(BaseProvider):
             "channelCount": channel_count,
             "desired": str(VesperType.MOBILE_SCHEDULE)
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_CQS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_CQS)
 
 
 class VesperType(StrEnum):

--- a/xbox/webapi/api/provider/eds.py
+++ b/xbox/webapi/api/provider/eds.py
@@ -22,7 +22,7 @@ class EDSProvider(BaseProvider):
 
     SEPERATOR = "."
 
-    def get_appchannel_channel_list(self, lineup_id):
+    async def get_appchannel_channel_list(self, lineup_id):
         """
         Get AppChannel channel list
 
@@ -30,13 +30,13 @@ class EDSProvider(BaseProvider):
             lineup_id (str): Lineup ID
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.EDS_URL + "/media/%s/tvchannels?" % self.client.language.locale
         params = {"channelLineupId": lineup_id}
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_appchannel_schedule(self, lineup_id, start_time, end_time, max_items, skip_items):
+    async def get_appchannel_schedule(self, lineup_id, start_time, end_time, max_items, skip_items):
         """
         Get AppChannel schedule / EPG
 
@@ -48,7 +48,7 @@ class EDSProvider(BaseProvider):
             skip_items (int): Count of items to skip
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.EDS_URL + "/media/%s/tvchannellineupguide?" % self.client.language.locale
         desired = [
@@ -68,9 +68,9 @@ class EDSProvider(BaseProvider):
             "channelLineupId": lineup_id,
             "desired": self.SEPERATOR.join(desired)
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_browse_query(self, order_by, desired, **kwargs):
+    async def get_browse_query(self, order_by, desired, **kwargs):
         """
         Get a browse query
 
@@ -95,9 +95,9 @@ class EDSProvider(BaseProvider):
             "desiredMediaItemTypes": str(desired)
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_recommendations(self, desired, **kwargs):
+    async def get_recommendations(self, desired, **kwargs):
         """
         Get recommended content suggestions
 
@@ -106,7 +106,7 @@ class EDSProvider(BaseProvider):
             **kwargs: Additional query parameters
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if isinstance(desired, list):
             desired = self.SEPERATOR.join(str(d) for d in desired)
@@ -116,9 +116,9 @@ class EDSProvider(BaseProvider):
             "desiredMediaItemTypes": str(desired)
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_related(self, id, desired, **kwargs):
+    async def get_related(self, id, desired, **kwargs):
         """
         Get related content for a specific Id
 
@@ -128,7 +128,7 @@ class EDSProvider(BaseProvider):
             **kwargs: Additional query parameters
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if isinstance(desired, list):
             desired = self.SEPERATOR.join(str(d) for d in desired)
@@ -139,9 +139,9 @@ class EDSProvider(BaseProvider):
             "desiredMediaItemTypes": str(desired)
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_fields(self, desired, **kwargs):
+    async def get_fields(self, desired, **kwargs):
         """
         Get Fields
 
@@ -150,7 +150,7 @@ class EDSProvider(BaseProvider):
             **kwargs: Additional query parameters
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if isinstance(desired, list):
             desired = self.SEPERATOR.join(desired)
@@ -160,9 +160,9 @@ class EDSProvider(BaseProvider):
             "desired": desired
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_details(self, ids, mediagroup, **kwargs):
+    async def get_details(self, ids, mediagroup, **kwargs):
         """
         Get details for a list of IDs in a specific media group
 
@@ -172,7 +172,7 @@ class EDSProvider(BaseProvider):
             **kwargs: Additional query parameters
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if isinstance(ids, list):
             ids = self.SEPERATOR.join(ids)
@@ -183,9 +183,9 @@ class EDSProvider(BaseProvider):
             "MediaGroup": str(mediagroup)
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_crossmediagroup_search(self, search_query, max_items, **kwargs):
+    async def get_crossmediagroup_search(self, search_query, max_items, **kwargs):
         """
         Do a crossmedia-group search (search for content for multiple devices)
 
@@ -195,7 +195,7 @@ class EDSProvider(BaseProvider):
             **kwargs: Additional query parameters
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.EDS_URL + "/media/%s/crossMediaGroupSearch?" % self.client.language.locale
         params = {
@@ -203,9 +203,9 @@ class EDSProvider(BaseProvider):
             "maxItems": max_items
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
-    def get_singlemediagroup_search(self, search_query, max_items, media_item_types, **kwargs):
+    async def get_singlemediagroup_search(self, search_query, max_items, media_item_types, **kwargs):
         """
         Do a singlemedia-group search
 
@@ -216,7 +216,7 @@ class EDSProvider(BaseProvider):
             **kwargs: Additional query parameters
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if isinstance(media_item_types, list):
             media_item_types = self.SEPERATOR.join(str(t) for t in media_item_types)
@@ -228,7 +228,7 @@ class EDSProvider(BaseProvider):
             "desiredMediaItemTypes": str(media_item_types)
         }
         params.update(kwargs)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_EDS)
 
 
 class MediaItemType(StrEnum):

--- a/xbox/webapi/api/provider/gameclips.py
+++ b/xbox/webapi/api/provider/gameclips.py
@@ -8,7 +8,7 @@ class GameclipProvider(BaseProvider):
     GAMECLIPS_METADATA_URL = "https://gameclipsmetadata.xboxlive.com"
     HEADERS_GAMECLIPS_METADATA = {'x-xbl-contract-version': '1'}
 
-    def get_recent_community_clips_by_title_id(self, title_id):
+    async def get_recent_community_clips_by_title_id(self, title_id):
         """
         Get recent community clips by Title Id
 
@@ -16,15 +16,15 @@ class GameclipProvider(BaseProvider):
             title_id (str): Title Id to get clips for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.GAMECLIPS_METADATA_URL + "/public/titles/%s/clips?" % title_id
         params = {
             "qualifier": "created"
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
 
-    def get_recent_own_clips(self, title_id=None, skip_items=0, max_items=25):
+    async def get_recent_own_clips(self, title_id=None, skip_items=0, max_items=25):
         """
         Get own recent clips, optionally filter for title Id
 
@@ -34,7 +34,7 @@ class GameclipProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.GAMECLIPS_METADATA_URL + "/users/me"
         if title_id:
@@ -45,9 +45,9 @@ class GameclipProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
 
-    def get_recent_clips_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
+    async def get_recent_clips_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
         """
         Get clips by XUID, optionally filter for title Id
 
@@ -58,7 +58,7 @@ class GameclipProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.GAMECLIPS_METADATA_URL + "/users/xuid(%s)" % xuid
         if title_id:
@@ -69,9 +69,9 @@ class GameclipProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
 
-    def get_saved_community_clips_by_title_id(self, title_id):
+    async def get_saved_community_clips_by_title_id(self, title_id):
         """
         Get saved community clips by Title Id
 
@@ -79,15 +79,15 @@ class GameclipProvider(BaseProvider):
             title_id (str): Title Id to get screenshots for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.GAMECLIPS_METADATA_URL + "/public/titles/%s/clips/saved" % title_id
         params = {
             "qualifier": "created"
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
 
-    def get_saved_own_clips(self, title_id=None, skip_items=0, max_items=25):
+    async def get_saved_own_clips(self, title_id=None, skip_items=0, max_items=25):
         """
         Get own saved clips, optionally filter for title Id an
 
@@ -97,7 +97,7 @@ class GameclipProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.GAMECLIPS_METADATA_URL + "/users/me"
         if title_id:
@@ -108,9 +108,9 @@ class GameclipProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
 
-    def get_saved_clips_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
+    async def get_saved_clips_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
         """
         Get saved clips by XUID, optionally filter for title Id
 
@@ -121,7 +121,7 @@ class GameclipProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.GAMECLIPS_METADATA_URL + "/users/xuid(%s)" % xuid
         if title_id:
@@ -132,4 +132,4 @@ class GameclipProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA)

--- a/xbox/webapi/api/provider/lists.py
+++ b/xbox/webapi/api/provider/lists.py
@@ -13,7 +13,7 @@ class ListsProvider(BaseProvider):
 
     SEPERATOR = "."
 
-    def remove_items(self, xuid, params, listname="XBLPins"):
+    async def remove_items(self, xuid, params, listname="XBLPins"):
         """
         Remove items from specific list, defaults to "XBLPins"
 
@@ -22,12 +22,12 @@ class ListsProvider(BaseProvider):
             listname (str): Name of list to edit
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.LISTS_URL + "/users/xuid(%s)/lists/PINS/%s" % (xuid, listname)
-        return self.client.session.delete(url, params=params, headers=self.HEADERS_LISTS)
+        return await self.client.session.delete(url, params=params, headers=self.HEADERS_LISTS)
 
-    def get_items(self, xuid, params, listname="XBLPins"):
+    async def get_items(self, xuid, params, listname="XBLPins"):
         """
         Get items from specific list, defaults to "XBLPins"
 
@@ -36,12 +36,12 @@ class ListsProvider(BaseProvider):
             listname (str): Name of list to edit
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.LISTS_URL + "/users/xuid(%s)/lists/PINS/%s" % (xuid, listname)
-        return self.client.session.get(url, params=params, headers=self.HEADERS_LISTS)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_LISTS)
 
-    def insert_items(self, xuid, params, listname="XBLPins"):
+    async def insert_items(self, xuid, params, listname="XBLPins"):
         """
         Insert items to specific list, defaults to "XBLPins"
 
@@ -50,12 +50,12 @@ class ListsProvider(BaseProvider):
             listname (str): Name of list to edit
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.LISTS_URL + "/users/xuid(%s)/lists/PINS/%s" % (xuid, listname)
-        return self.client.session.post(url, params=params, headers=self.HEADERS_LISTS)
+        return await self.client.session.post(url, params=params, headers=self.HEADERS_LISTS)
 
-    def update_items(self, xuid, params, listname="XBLPins"):
+    async def update_items(self, xuid, params, listname="XBLPins"):
         """
         Update items in specific list, defaults to "XBLPins"
 
@@ -64,7 +64,7 @@ class ListsProvider(BaseProvider):
             listname (str): Name of list to edit
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.LISTS_URL + "/users/xuid(%s)/lists/PINS/%s" % (xuid, listname)
-        return self.client.session.put(url, params=params, headers=self.HEADERS_LISTS)
+        return await self.client.session.put(url, params=params, headers=self.HEADERS_LISTS)

--- a/xbox/webapi/api/provider/message.py
+++ b/xbox/webapi/api/provider/message.py
@@ -8,7 +8,7 @@ class MessageProvider(BaseProvider):
     MSG_URL = "https://msg.xboxlive.com"
     HEADERS_MESSAGE = {'x-xbl-contract-version': '1'}
 
-    def get_message_inbox(self, skip_items=0, max_items=100):
+    async def get_message_inbox(self, skip_items=0, max_items=100):
         """
         Get messages
 
@@ -17,16 +17,16 @@ class MessageProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.MSG_URL + "/users/xuid(%s)/inbox" % self.client.xuid
         params = {
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_MESSAGE)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_MESSAGE)
 
-    def get_message(self, message_id):
+    async def get_message(self, message_id):
         """
         Get detailed message info
 
@@ -34,12 +34,12 @@ class MessageProvider(BaseProvider):
             message_id (str): Message Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.MSG_URL + "/users/xuid(%s)/inbox/%s" % (self.client.xuid, message_id)
-        return self.client.session.get(url, headers=self.HEADERS_MESSAGE)
+        return await self.client.session.get(url, headers=self.HEADERS_MESSAGE)
 
-    def delete_message(self, message_id):
+    async def delete_message(self, message_id):
         """
         Delete message
 
@@ -49,12 +49,12 @@ class MessageProvider(BaseProvider):
             message_id (str): Message Id
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.MSG_URL + "/users/xuid(%s)/inbox/%s" % (self.client.xuid, message_id)
-        return self.client.session.delete(url, headers=self.HEADERS_MESSAGE)
+        return await self.client.session.delete(url, headers=self.HEADERS_MESSAGE)
 
-    def send_message(self, message_text, gamertags=None, xuids=None):
+    async def send_message(self, message_text, gamertags=None, xuids=None):
         """
         Send message to a list of gamertags
 
@@ -65,7 +65,7 @@ class MessageProvider(BaseProvider):
             gamertags (list): List of gamertags
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not isinstance(message_text, str):
             raise TypeError('Expecting message_text string')
@@ -88,4 +88,4 @@ class MessageProvider(BaseProvider):
             },
             'messageText': message_text
         }
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_MESSAGE)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_MESSAGE)

--- a/xbox/webapi/api/provider/people.py
+++ b/xbox/webapi/api/provider/people.py
@@ -8,27 +8,27 @@ class PeopleProvider(BaseProvider):
     SOCIAL_URL = "https://social.xboxlive.com"
     HEADERS_SOCIAL = {'x-xbl-contract-version': '1'}
 
-    def get_friends_own(self):
+    async def get_friends_own(self):
         """
         Get friendlist of own profile
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SOCIAL_URL + "/users/me/people"
-        return self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        return await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
 
-    def get_friends_summary_own(self):
+    async def get_friends_summary_own(self):
         """
         Get friendlist summary of own profile
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SOCIAL_URL + "/users/me/summary"
-        return self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        return await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
 
-    def get_friends_summary_by_xuid(self, xuid):
+    async def get_friends_summary_by_xuid(self, xuid):
         """
         Get friendlist summary of user by xuid
 
@@ -36,12 +36,12 @@ class PeopleProvider(BaseProvider):
             xuid (str): XUID to request summary from
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SOCIAL_URL + "/users/xuid(%s)/summary" % xuid
-        return self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        return await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
     
-    def get_friends_by_xuid(self, xuid):
+    async def get_friends_by_xuid(self, xuid):
         """
         Get friendlist of user by xuid
 
@@ -49,12 +49,12 @@ class PeopleProvider(BaseProvider):
             xuid (str): XUID to request summary from
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SOCIAL_URL + "/users/xuid(%s)/people" % xuid
-        return self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        return await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
 
-    def get_friends_summary_by_gamertag(self, gamertag):
+    async def get_friends_summary_by_gamertag(self, gamertag):
         """
         Get friendlist summary of user by xuid
 
@@ -62,12 +62,12 @@ class PeopleProvider(BaseProvider):
             gamertag (str): XUID to request friendlist from
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SOCIAL_URL + "/users/gt(%s)/summary" % gamertag
-        return self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        return await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
 
-    def get_friends_own_batch(self, xuids):
+    async def get_friends_own_batch(self, xuids):
         """
         Get friends metadata by providing a list of XUIDs
 
@@ -75,7 +75,7 @@ class PeopleProvider(BaseProvider):
             xuids (list): List of XUIDs
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not isinstance(xuids, list):
             raise Exception("xuids parameter is not a list")
@@ -84,4 +84,4 @@ class PeopleProvider(BaseProvider):
         post_data = {
             "xuids": [str(xuid) for xuid in xuids]
         }
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_SOCIAL)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_SOCIAL)

--- a/xbox/webapi/api/provider/presence.py
+++ b/xbox/webapi/api/provider/presence.py
@@ -18,7 +18,7 @@ class PresenceProvider(BaseProvider):
         'Accept': 'application/json'
     }
 
-    def get_presence_batch(self, xuids, online_only=False, presence_level=PresenceLevel.USER):
+    async def get_presence_batch(self, xuids, online_only=False, presence_level=PresenceLevel.USER):
         """
         Get presence for list of xuids
 
@@ -28,7 +28,7 @@ class PresenceProvider(BaseProvider):
             presence_level (str): Filter level
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not isinstance(xuids, list):
             raise Exception("xuids parameter is not a list")
@@ -41,9 +41,9 @@ class PresenceProvider(BaseProvider):
             'onlineOnly': online_only,
             'level': presence_level
         }
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_PRESENCE)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_PRESENCE)
 
-    def get_presence_own(self, presence_level=PresenceLevel.ALL):
+    async def get_presence_own(self, presence_level=PresenceLevel.ALL):
         """
         Get presence of own profile
 
@@ -51,10 +51,10 @@ class PresenceProvider(BaseProvider):
             presence_level (str): Filter level
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.PRESENCE_URL + "/users/me"
         params = {
             'level': presence_level
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_PRESENCE)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_PRESENCE)

--- a/xbox/webapi/api/provider/profile.py
+++ b/xbox/webapi/api/provider/profile.py
@@ -13,7 +13,7 @@ class ProfileProvider(BaseProvider):
     }
     SEPARATOR = ","
 
-    def get_profiles(self, xuid_list):
+    async def get_profiles(self, xuid_list):
         """
         Get profile info for list of xuids
 
@@ -21,7 +21,7 @@ class ProfileProvider(BaseProvider):
             xuid_list (list): List of xuids
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         post_data = {
             "settings": [
@@ -43,9 +43,9 @@ class ProfileProvider(BaseProvider):
             "userIds": [int(xuid) for xuid in xuid_list]
         }
         url = self.PROFILE_URL + "/users/batch/profile/settings"
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_PROFILE)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_PROFILE)
 
-    def get_profile_by_xuid(self, target_xuid):
+    async def get_profile_by_xuid(self, target_xuid):
         """
         Get Userprofile by xuid
 
@@ -53,7 +53,7 @@ class ProfileProvider(BaseProvider):
             target_xuid (int): XUID to get profile for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.PROFILE_URL + "/users/xuid(%s)/profile/settings?" % target_xuid
         params = {
@@ -65,9 +65,9 @@ class ProfileProvider(BaseProvider):
                 ProfileSettings.XBOX_ONE_REP
             ])
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_PROFILE)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_PROFILE)
 
-    def get_profile_by_gamertag(self, gamertag):
+    async def get_profile_by_gamertag(self, gamertag):
         """
         Get Userprofile by gamertag
 
@@ -75,7 +75,7 @@ class ProfileProvider(BaseProvider):
             gamertag (str): Gamertag to get profile for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.PROFILE_URL + "/users/gt(%s)/profile/settings?" % gamertag
         params = {
@@ -87,7 +87,7 @@ class ProfileProvider(BaseProvider):
                 ProfileSettings.XBOX_ONE_REP
             ])
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_PROFILE)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_PROFILE)
 
 
 class ProfileSettings(object):

--- a/xbox/webapi/api/provider/screenshots.py
+++ b/xbox/webapi/api/provider/screenshots.py
@@ -8,7 +8,7 @@ class ScreenshotsProvider(BaseProvider):
     SCREENSHOTS_METADATA_URL = "https://screenshotsmetadata.xboxlive.com"
     HEADERS_SCREENSHOTS_METADATA = {'x-xbl-contract-version': '5'}
 
-    def get_recent_community_screenshots_by_title_id(self, title_id):
+    async def get_recent_community_screenshots_by_title_id(self, title_id):
         """
         Get recent community screenshots by Title Id
 
@@ -16,15 +16,15 @@ class ScreenshotsProvider(BaseProvider):
             title_id (str): Title Id to get screenshots for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SCREENSHOTS_METADATA_URL + "/public/titles/%s/screenshots" % title_id
         params = {
             "qualifier": "created"
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
 
-    def get_recent_own_screenshots(self, title_id=None, skip_items=0, max_items=25):
+    async def get_recent_own_screenshots(self, title_id=None, skip_items=0, max_items=25):
         """
         Get own recent screenshots, optionally filter for title Id
 
@@ -34,7 +34,7 @@ class ScreenshotsProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SCREENSHOTS_METADATA_URL + "/users/me"
         if title_id:
@@ -45,9 +45,9 @@ class ScreenshotsProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
 
-    def get_recent_screenshots_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
+    async def get_recent_screenshots_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
         """
         Get recent screenshots by XUID, optionally filter for title Id
 
@@ -58,7 +58,7 @@ class ScreenshotsProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SCREENSHOTS_METADATA_URL + "/users/xuid(%s)" % xuid
         if title_id:
@@ -69,9 +69,9 @@ class ScreenshotsProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
 
-    def get_saved_community_screenshots_by_title_id(self, title_id):
+    async def get_saved_community_screenshots_by_title_id(self, title_id):
         """
         Get saved community screenshots by Title Id
 
@@ -79,15 +79,15 @@ class ScreenshotsProvider(BaseProvider):
             title_id (str): Title Id to get screenshots for
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SCREENSHOTS_METADATA_URL + "/public/titles/%s/screenshots/saved" % title_id
         params = {
             "qualifier": "created"
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
 
-    def get_saved_own_screenshots(self, title_id=None, skip_items=0, max_items=25):
+    async def get_saved_own_screenshots(self, title_id=None, skip_items=0, max_items=25):
         """
         Get own saved screenshots, optionally filter for title Id an
 
@@ -97,7 +97,7 @@ class ScreenshotsProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SCREENSHOTS_METADATA_URL + "/users/me"
         if title_id:
@@ -108,9 +108,9 @@ class ScreenshotsProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
 
-    def get_saved_screenshots_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
+    async def get_saved_screenshots_by_xuid(self, xuid, title_id=None, skip_items=0, max_items=25):
         """
         Get saved screenshots by XUID, optionally filter for title Id
 
@@ -121,7 +121,7 @@ class ScreenshotsProvider(BaseProvider):
             max_items (int): Maximum item count to load
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.SCREENSHOTS_METADATA_URL + "/users/xuid(%s)" % xuid
         if title_id:
@@ -132,4 +132,4 @@ class ScreenshotsProvider(BaseProvider):
             'skipItems': skip_items,
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA)

--- a/xbox/webapi/api/provider/titlehub.py
+++ b/xbox/webapi/api/provider/titlehub.py
@@ -34,7 +34,7 @@ class TitlehubProvider(BaseProvider):
         super(TitlehubProvider, self).__init__(client)
         self.HEADERS_TITLEHUB.update({'Accept-Language': self.client.language.locale})
 
-    def get_title_history(self, xuid, fields=None, max_items=5):
+    async def get_title_history(self, xuid, fields=None, max_items=5):
         """
         Get recently played titles
 
@@ -44,7 +44,7 @@ class TitlehubProvider(BaseProvider):
             max_items (int): Maximum items
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not fields:
             fields = [TitleFields.ACHIEVEMENT, TitleFields.IMAGE, TitleFields.SERVICE_CONFIG_ID]
@@ -54,9 +54,9 @@ class TitlehubProvider(BaseProvider):
         params = {
             'maxItems': max_items
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_TITLEHUB)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_TITLEHUB)
 
-    def get_title_info(self, title_id, fields=None):
+    async def get_title_info(self, title_id, fields=None):
         """
         Get info for specific title
 
@@ -65,7 +65,7 @@ class TitlehubProvider(BaseProvider):
             fields (list): Members of :class:`TitleFields`
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not fields:
             fields = [
@@ -75,9 +75,9 @@ class TitlehubProvider(BaseProvider):
         fields = self.SEPARATOR.join(fields)
 
         url = self.TITLEHUB_URL + "/users/xuid(%s)/titles/titleid(%s)/decoration/%s" % (self.client.xuid, title_id, fields)
-        return self.client.session.get(url, headers=self.HEADERS_TITLEHUB)
+        return await self.client.session.get(url, headers=self.HEADERS_TITLEHUB)
 
-    def get_titles_batch(self, pfns, fields=None):
+    async def get_titles_batch(self, pfns, fields=None):
         """
         Get Title info via PFN ids
 
@@ -86,7 +86,7 @@ class TitlehubProvider(BaseProvider):
             fields (list): Members of :class:`TitleFields`
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not isinstance(pfns, list):
             raise ValueError("PFN parameter requires list of strings")
@@ -100,4 +100,4 @@ class TitlehubProvider(BaseProvider):
             "pfns": pfns,
             "windowsPhoneProductIds": []
         }
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_TITLEHUB)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_TITLEHUB)

--- a/xbox/webapi/api/provider/usersearch.py
+++ b/xbox/webapi/api/provider/usersearch.py
@@ -8,7 +8,7 @@ class UserSearchProvider(BaseProvider):
     USERSEARCH_URL = "https://usersearch.xboxlive.com"
     HEADERS_USER_SEARCH = {'x-xbl-contract-version': '1'}
 
-    def get_live_search(self, query):
+    async def get_live_search(self, query):
         """
         Get userprofiles for search query
 
@@ -16,10 +16,10 @@ class UserSearchProvider(BaseProvider):
             query (str): Search query
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         url = self.USERSEARCH_URL + "/suggest?"
         params = {
             "q": query
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_USER_SEARCH)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_USER_SEARCH)

--- a/xbox/webapi/api/provider/userstats.py
+++ b/xbox/webapi/api/provider/userstats.py
@@ -10,7 +10,7 @@ class UserStatsProvider(BaseProvider):
     HEADERS_USERSTATS_WITH_METADATA = {'x-xbl-contract-version': '3'}
     SEPERATOR = ","
 
-    def get_stats(self, xuid, service_config_id, stats_fields=None):
+    async def get_stats(self, xuid, service_config_id, stats_fields=None):
         """
         Get userstats
 
@@ -20,16 +20,16 @@ class UserStatsProvider(BaseProvider):
             stats_fields (list): List of stats fields to acquire
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not stats_fields:
             stats_fields = [GeneralStatsField.MINUTES_PLAYED]
         stats = self.SEPERATOR.join(stats_fields)
 
         url = self.USERSTATS_URL + "/users/xuid(%s)/scids/%s/stats/%s" % (xuid, service_config_id, stats)
-        return self.client.session.get(url, headers=self.HEADERS_USERSTATS)
+        return await self.client.session.get(url, headers=self.HEADERS_USERSTATS)
 
-    def get_stats_with_metadata(self, xuid, service_config_id, stats_fields=None):
+    async def get_stats_with_metadata(self, xuid, service_config_id, stats_fields=None):
         """
         Get userstats including metadata for each stat (if available)
 
@@ -39,7 +39,7 @@ class UserStatsProvider(BaseProvider):
             stats_fields (list): List of stats fields to acquire
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not stats_fields:
             stats_fields = [GeneralStatsField.MINUTES_PLAYED]
@@ -49,9 +49,9 @@ class UserStatsProvider(BaseProvider):
         params = {
             'include': 'valuemetadata'
         }
-        return self.client.session.get(url, params=params, headers=self.HEADERS_USERSTATS_WITH_METADATA)
+        return await self.client.session.get(url, params=params, headers=self.HEADERS_USERSTATS_WITH_METADATA)
 
-    def get_stats_batch(self, xuids, title_id, stats_fields=None):
+    async def get_stats_batch(self, xuids, title_id, stats_fields=None):
         """
         Get userstats in batch mode
 
@@ -61,7 +61,7 @@ class UserStatsProvider(BaseProvider):
             stats_fields (list): List of stats fields to acquire
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not isinstance(xuids, list):
             raise ValueError('Xuids parameter is not a list')
@@ -81,9 +81,9 @@ class UserStatsProvider(BaseProvider):
             'stats': [dict(name=stat, titleId=int(title_id)) for stat in stats_fields],
             'xuids': [str(xid) for xid in xuids]
         }
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_USERSTATS)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_USERSTATS)
 
-    def get_stats_batch_by_scid(self, xuids, service_config_id, stats_fields=None):
+    async def get_stats_batch_by_scid(self, xuids, service_config_id, stats_fields=None):
         """
         Get userstats in batch mode, via scid
 
@@ -93,7 +93,7 @@ class UserStatsProvider(BaseProvider):
             stats_fields (list): List of stats fields to acquire
 
         Returns:
-            :class:`requests.Response`: HTTP Response
+            :class:`aiohttp.ClientResponse`: HTTP Response
         """
         if not isinstance(xuids, list):
             raise ValueError('Xuids parameter is not a list')
@@ -114,7 +114,7 @@ class UserStatsProvider(BaseProvider):
             'stats': [dict(name=stat, scid=service_config_id) for stat in stats_fields],
             'xuids': [str(xid) for xid in xuids]
         }
-        return self.client.session.post(url, json=post_data, headers=self.HEADERS_USERSTATS)
+        return await self.client.session.post(url, json=post_data, headers=self.HEADERS_USERSTATS)
 
 
 class GeneralStatsField(object):


### PR DESCRIPTION
I'm offering this PR for switching from requests to aiohttp to add asyncio compatibility with this lib, as requested by #7 (and my personal needs).

Please note this is currently a work in progress, the scripts part haven't been updated yet as well as the tests, which will require to change the betamax dependency (because betamax is compatible only with requests).

I just wanted to share what I've already done, and wanted to know if you're interested by this kind of change.

## How to use?

Here's some code example:

```python
async def main():
    try:
        auth_mgr = await AuthenticationManager.from_file('tokens.json')
    except FileNotFoundError:
        auth_mgr = await AuthenticationManager.create()
        auth_mgr.email_address = "pyxb-testing@outlook.com"
        auth_mgr.password = "password"
    await auth_mgr.authenticate()
    await auth_mgr.close()  # required to properly close aiohttp.ClientSession

    client = await XboxLiveClient.create(auth_mgr.userinfo.userhash, auth_mgr.xsts_token.jwt, auth_mgr.userinfo.xuid)
    profile = await client.profile.get_profile_by_xuid("2669321029139235")
    profile = await profile.json()
    print(profile)

    achievements = await client.achievements.get_achievements_xboxone_gameprogress("2669321029139235", 219630713)
    achievements = await achievements.json()
    print(achievements)

    await client.close()  # required to properly close aiohttp.ClientSession

asyncio.run(main())
```