### PR TITLE
Various fixes and adding XAD and XAT token responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.10 (2020-11-13)
+
+* Add models for XAD and XAT Token responses
+* Fix message.get_inbox() (Setting text field as Optional) (Fixes issue #37)
+* Fix OAuth2TokenResponse incase no refresh_token is returned by authentication (Fixes issue #36)
+* Fix pytest warnings (unclosed ClientSession, usage of deprecated ClientResponse field)
+* Fix CatalogResponse.Products[].DisplaySkuAvailabilities[].Availabilities - Set order_management_data as Optional
+* Enable passing extra values to headers, params and data for all providers via kwargs (extra_headers, extra_params, extra_data)
+* Fix GameclipsResponse
+
 ## 2.0.9 (2020-11-02)
 
 * Fix titlehub endpoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,15 +21,15 @@ collect_ignore = ["setup.py"]
 
 @pytest.fixture(scope="function")
 async def auth_mgr(event_loop):
-    mgr = AuthenticationManager(
-        ClientSession(loop=event_loop), "abc", "123", "http://localhost"
-    )
+    session = ClientSession(loop=event_loop)
+    mgr = AuthenticationManager(session, "abc", "123", "http://localhost")
     mgr.oauth = OAuth2TokenResponse.parse_raw(get_response("auth_oauth2_token"))
     mgr.user_token = XAUResponse.parse_raw(get_response("auth_user_token"))
     mgr.xsts_token = XSTSResponse.parse_raw(get_response("auth_xsts_token"))
-    return mgr
+    yield mgr
+    await session.close()
 
 
 @pytest.fixture(scope="function")
 def xbl_client(auth_mgr):
-    return XboxLiveClient(auth_mgr)
+    yield XboxLiveClient(auth_mgr)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -32,7 +32,7 @@ async def test_claim_gamertag_error(aresponses, xbl_client):
         await xbl_client.account.claim_gamertag("2669321029139235", "PrettyPony")
     await xbl_client._auth_mgr.session.close()
 
-    assert err.value.code == 500
+    assert err.value.status == 500
     aresponses.assert_plan_strictly_followed()
 
 
@@ -61,5 +61,5 @@ async def test_change_gamertag_error(aresponses, xbl_client):
         await xbl_client.account.change_gamertag("2669321029139235", "PrettyPony")
     await xbl_client._auth_mgr.session.close()
 
-    assert err.value.code == 500
+    assert err.value.status == 500
     aresponses.assert_plan_strictly_followed()

--- a/xbox/webapi/api/client.py
+++ b/xbox/webapi/api/client.py
@@ -47,6 +47,13 @@ class Session:
     ) -> ClientResponse:
         """Proxy Request and add Auth/CV headers."""
         headers = kwargs.pop("headers", {})
+        params = kwargs.pop("params", None)
+        data = kwargs.pop("data", None)
+
+        # Extra, user supplied values
+        extra_headers = kwargs.pop("extra_headers", None)
+        extra_params = kwargs.pop("extra_params", None)
+        extra_data = kwargs.pop("extra_data", None)
 
         if include_auth:
             # Ensure tokens valid
@@ -59,11 +66,20 @@ class Session:
         if include_cv:
             headers["MS-CV"] = self._cv.increment()
 
+        # Extend with optionally supplied values
+        if extra_headers:
+            headers.update(extra_headers)
+        if extra_params:
+            # query parameters
+            params = params or {}
+            params.update(extra_params)
+        if extra_data:
+            # form encoded post data
+            data = data or {}
+            data.update(extra_data)
+
         return await self._auth_mgr.session.request(
-            method,
-            url,
-            **kwargs,
-            headers=headers,
+            method, url, **kwargs, headers=headers, params=params, data=data
         )
 
     async def get(self, url: str, **kwargs: Any) -> ClientResponse:

--- a/xbox/webapi/api/provider/account/__init__.py
+++ b/xbox/webapi/api/provider/account/__init__.py
@@ -12,7 +12,7 @@ class AccountProvider(BaseProvider):
     HEADERS_USER_MGT = {"x-xbl-contract-version": "1"}
     HEADERS_ACCOUNT = {"x-xbl-contract-version": "2"}
 
-    async def claim_gamertag(self, xuid, gamertag) -> ClaimGamertagResult:
+    async def claim_gamertag(self, xuid, gamertag, **kwargs) -> ClaimGamertagResult:
         """
         Claim gamertag
 
@@ -32,7 +32,7 @@ class AccountProvider(BaseProvider):
         url = self.BASE_URL_USER_MGT + "/gamertags/reserve"
         post_data = {"Gamertag": gamertag, "ReservationId": str(xuid)}
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_USER_MGT
+            url, json=post_data, headers=self.HEADERS_USER_MGT, **kwargs
         )
         try:
             return ClaimGamertagResult(resp.status)
@@ -40,7 +40,7 @@ class AccountProvider(BaseProvider):
             resp.raise_for_status()
 
     async def change_gamertag(
-        self, xuid, gamertag, preview=False
+        self, xuid, gamertag, preview=False, **kwargs
     ) -> ChangeGamertagResult:
         """
         Change your gamertag.
@@ -63,7 +63,7 @@ class AccountProvider(BaseProvider):
             "reservationId": int(xuid),
         }
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_ACCOUNT
+            url, json=post_data, headers=self.HEADERS_ACCOUNT, **kwargs
         )
         try:
             return ChangeGamertagResult(resp.status)

--- a/xbox/webapi/api/provider/achievements/__init__.py
+++ b/xbox/webapi/api/provider/achievements/__init__.py
@@ -18,7 +18,7 @@ class AchievementsProvider(BaseProvider):
     HEADERS_GAME_PROGRESS = {"x-xbl-contract-version": "2"}
 
     async def get_achievements_detail_item(
-        self, xuid, service_config_id, achievement_id
+        self, xuid, service_config_id, achievement_id, **kwargs
     ) -> AchievementResponse:
         """
         Get achievement detail for specific item
@@ -32,12 +32,14 @@ class AchievementsProvider(BaseProvider):
             :class:`AchievementResponse`: Achievement Response
         """
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/achievements/{service_config_id}/{achievement_id}"
-        resp = await self.client.session.get(url, headers=self.HEADERS_GAME_PROGRESS)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_GAME_PROGRESS, **kwargs
+        )
         resp.raise_for_status()
         return AchievementResponse.parse_raw(await resp.text())
 
     async def get_achievements_xbox360_all(
-        self, xuid, title_id
+        self, xuid, title_id, **kwargs
     ) -> Achievement360Response:
         """
         Get all achievements for specific X360 title Id
@@ -52,13 +54,13 @@ class AchievementsProvider(BaseProvider):
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/titleachievements?"
         params = {"titleId": title_id}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAME_360_PROGRESS
+            url, params=params, headers=self.HEADERS_GAME_360_PROGRESS, **kwargs
         )
         resp.raise_for_status()
         return Achievement360Response.parse_raw(await resp.text())
 
     async def get_achievements_xbox360_earned(
-        self, xuid, title_id
+        self, xuid, title_id, **kwargs
     ) -> Achievement360Response:
         """
         Get earned achievements for specific X360 title id
@@ -73,13 +75,13 @@ class AchievementsProvider(BaseProvider):
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/achievements?"
         params = {"titleId": title_id}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAME_360_PROGRESS
+            url, params=params, headers=self.HEADERS_GAME_360_PROGRESS, **kwargs
         )
         resp.raise_for_status()
         return Achievement360Response.parse_raw(await resp.text())
 
     async def get_achievements_xbox360_recent_progress_and_info(
-        self, xuid
+        self, xuid, **kwargs
     ) -> Achievement360ProgressResponse:
         """
         Get recent achievement progress and information
@@ -92,13 +94,13 @@ class AchievementsProvider(BaseProvider):
         """
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/history/titles"
         resp = await self.client.session.get(
-            url, headers=self.HEADERS_GAME_360_PROGRESS
+            url, headers=self.HEADERS_GAME_360_PROGRESS, **kwargs
         )
         resp.raise_for_status()
         return Achievement360ProgressResponse.parse_raw(await resp.text())
 
     async def get_achievements_xboxone_gameprogress(
-        self, xuid, title_id
+        self, xuid, title_id, **kwargs
     ) -> AchievementResponse:
         """
         Get gameprogress for Xbox One title
@@ -113,13 +115,13 @@ class AchievementsProvider(BaseProvider):
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/achievements?"
         params = {"titleId": title_id}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAME_PROGRESS
+            url, params=params, headers=self.HEADERS_GAME_PROGRESS, **kwargs
         )
         resp.raise_for_status()
         return AchievementResponse.parse_raw(await resp.text())
 
     async def get_achievements_xboxone_recent_progress_and_info(
-        self, xuid
+        self, xuid, **kwargs
     ) -> RecentProgressResponse:
         """
         Get recent achievement progress and information
@@ -131,6 +133,8 @@ class AchievementsProvider(BaseProvider):
             :class:`RecentProgressResponse`: Recent Progress Response
         """
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/history/titles"
-        resp = await self.client.session.get(url, headers=self.HEADERS_GAME_PROGRESS)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_GAME_PROGRESS, **kwargs
+        )
         resp.raise_for_status()
         return RecentProgressResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/catalog/__init__.py
+++ b/xbox/webapi/api/provider/catalog/__init__.py
@@ -18,7 +18,10 @@ class CatalogProvider(BaseProvider):
     SEPERATOR = ","
 
     async def get_products(
-        self, big_ids: List[str], fields: FieldsTemplate = FieldsTemplate.DETAILS
+        self,
+        big_ids: List[str],
+        fields: FieldsTemplate = FieldsTemplate.DETAILS,
+        **kwargs,
     ) -> CatalogResponse:
         """Lookup product by Big IDs."""
         ids = self.SEPERATOR.join(big_ids)
@@ -30,7 +33,9 @@ class CatalogProvider(BaseProvider):
             "market": self.client.language.short_id,
         }
         url = f"{self.CATALOG_URL}/v7.0/products"
-        resp = await self.client.session.get(url, params=params, include_auth=False)
+        resp = await self.client.session.get(
+            url, params=params, include_auth=False, **kwargs
+        )
         resp.raise_for_status()
         return CatalogResponse.parse_raw(await resp.text())
 
@@ -40,6 +45,7 @@ class CatalogProvider(BaseProvider):
         id_type: AlternateIdType,
         fields: FieldsTemplate = FieldsTemplate.DETAILS,
         top: int = 25,
+        **kwargs,
     ) -> CatalogResponse:
         """Lookup product by Alternate ID."""
         params = {
@@ -51,12 +57,18 @@ class CatalogProvider(BaseProvider):
             "value": id,
         }
         url = f"{self.CATALOG_URL}/v7.0/products/lookup"
-        resp = await self.client.session.get(url, params=params, include_auth=False)
+        resp = await self.client.session.get(
+            url, params=params, include_auth=False, **kwargs
+        )
         resp.raise_for_status()
         return CatalogResponse.parse_raw(await resp.text())
 
     async def product_search(
-        self, query: str, platform: PlatformType = PlatformType.XBOX, top: int = 5
+        self,
+        query: str,
+        platform: PlatformType = PlatformType.XBOX,
+        top: int = 5,
+        **kwargs,
     ) -> CatalogSearchResponse:
         """Search for products by name."""
         params = {
@@ -68,6 +80,8 @@ class CatalogProvider(BaseProvider):
             "topProducts": top,
         }
         url = f"{self.CATALOG_URL}/v7.0/productFamilies/autosuggest"
-        resp = await self.client.session.get(url, params=params, include_auth=False)
+        resp = await self.client.session.get(
+            url, params=params, include_auth=False, **kwargs
+        )
         resp.raise_for_status()
         return CatalogSearchResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/catalog/models.py
+++ b/xbox/webapi/api/provider/catalog/models.py
@@ -324,7 +324,7 @@ class Availability(PascalCaseModel):
     conditions: Optional[Conditions]
     last_modified_date: Optional[datetime]
     markets: Optional[List[str]]
-    order_management_data: OrderManagementData
+    order_management_data: Optional[OrderManagementData]
     properties: Optional[AvailabilityProperties]
     sku_id: Optional[str]
     display_rank: Optional[int]

--- a/xbox/webapi/api/provider/cqs/__init__.py
+++ b/xbox/webapi/api/provider/cqs/__init__.py
@@ -25,7 +25,7 @@ class CQSProvider(BaseProvider):
     }
 
     async def get_channel_list(
-        self, locale_info: str, headend_id: str
+        self, locale_info: str, headend_id: str, **kwargs
     ) -> CqsChannelListResponse:
         """
         Get stump channel list
@@ -40,7 +40,7 @@ class CQSProvider(BaseProvider):
         url = self.CQS_URL + f"/epg/{locale_info}/lineups/{headend_id}/channels"
         params = {"desired": "vesper_mobile_lineup"}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_CQS
+            url, params=params, headers=self.HEADERS_CQS, **kwargs
         )
         resp.raise_for_status()
         return CqsChannelListResponse.parse_raw(await resp.text())
@@ -53,6 +53,7 @@ class CQSProvider(BaseProvider):
         duration_minutes: int,
         channel_skip: int,
         channel_count: int,
+        **kwargs,
     ) -> CqsScheduleResponse:
         """
         Get stump epg data
@@ -77,7 +78,7 @@ class CQSProvider(BaseProvider):
             "desired": "vesper_mobile_schedule",
         }
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_CQS
+            url, params=params, headers=self.HEADERS_CQS, **kwargs
         )
         resp.raise_for_status()
         return CqsScheduleResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/gameclips/__init__.py
+++ b/xbox/webapi/api/provider/gameclips/__init__.py
@@ -10,7 +10,7 @@ class GameclipProvider(BaseProvider):
     HEADERS_GAMECLIPS_METADATA = {"x-xbl-contract-version": "1"}
 
     async def get_recent_community_clips_by_title_id(
-        self, title_id: str
+        self, title_id: str, **kwargs
     ) -> GameclipsResponse:
         """
         Get recent community clips by Title Id
@@ -24,13 +24,13 @@ class GameclipProvider(BaseProvider):
         url = self.GAMECLIPS_METADATA_URL + f"/public/titles/{title_id}/clips"
         params = {"qualifier": "created"}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA
+            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return GameclipsResponse.parse_raw(await resp.text())
 
     async def get_recent_own_clips(
-        self, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self, title_id: str = None, skip_items: int = 0, max_items: int = 25, **kwargs
     ) -> GameclipsResponse:
         """
         Get own recent clips, optionally filter for title Id
@@ -50,13 +50,18 @@ class GameclipProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA
+            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return GameclipsResponse.parse_raw(await resp.text())
 
     async def get_recent_clips_by_xuid(
-        self, xuid: str, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self,
+        xuid: str,
+        title_id: str = None,
+        skip_items: int = 0,
+        max_items: int = 25,
+        **kwargs,
     ) -> GameclipsResponse:
         """
         Get clips by XUID, optionally filter for title Id
@@ -77,13 +82,13 @@ class GameclipProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA
+            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return GameclipsResponse.parse_raw(await resp.text())
 
     async def get_saved_community_clips_by_title_id(
-        self, title_id: str
+        self, title_id: str, **kwargs
     ) -> GameclipsResponse:
         """
         Get saved community clips by Title Id
@@ -97,13 +102,13 @@ class GameclipProvider(BaseProvider):
         url = self.GAMECLIPS_METADATA_URL + f"/public/titles/{title_id}/clips/saved"
         params = {"qualifier": "created"}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA
+            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return GameclipsResponse.parse_raw(await resp.text())
 
     async def get_saved_own_clips(
-        self, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self, title_id: str = None, skip_items: int = 0, max_items: int = 25, **kwargs
     ) -> GameclipsResponse:
         """
         Get own saved clips, optionally filter for title Id an
@@ -123,13 +128,18 @@ class GameclipProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA
+            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return GameclipsResponse.parse_raw(await resp.text())
 
     async def get_saved_clips_by_xuid(
-        self, xuid: str, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self,
+        xuid: str,
+        title_id: str = None,
+        skip_items: int = 0,
+        max_items: int = 25,
+        **kwargs,
     ) -> GameclipsResponse:
         """
         Get saved clips by XUID, optionally filter for title Id
@@ -150,7 +160,7 @@ class GameclipProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA
+            url, params=params, headers=self.HEADERS_GAMECLIPS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return GameclipsResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/gameclips/models.py
+++ b/xbox/webapi/api/provider/gameclips/models.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from xbox.webapi.common.models import CamelCaseModel
 
@@ -50,7 +50,7 @@ class GameClip(CamelCaseModel):
 
 
 class PagingInfo(CamelCaseModel):
-    continuation_token: str
+    continuation_token: Optional[str]
 
 
 class GameclipsResponse(CamelCaseModel):

--- a/xbox/webapi/api/provider/lists/__init__.py
+++ b/xbox/webapi/api/provider/lists/__init__.py
@@ -12,7 +12,7 @@ class ListsProvider(BaseProvider):
     SEPERATOR = "."
 
     async def remove_items(
-        self, xuid: str, post_body: dict, listname: str = "XBLPins"
+        self, xuid: str, post_body: dict, listname: str = "XBLPins", **kwargs
     ) -> ListMetadata:
         """
         Remove items from specific list, defaults to "XBLPins"
@@ -26,12 +26,14 @@ class ListsProvider(BaseProvider):
         """
         url = self.LISTS_URL + f"/users/xuid({xuid})/lists/PINS/{listname}"
         resp = await self.client.session.delete(
-            url, json=post_body, headers=self.HEADERS_LISTS
+            url, json=post_body, headers=self.HEADERS_LISTS, **kwargs
         )
         resp.raise_for_status()
         return ListMetadata.parse_raw(await resp.text())
 
-    async def get_items(self, xuid: str, listname: str = "XBLPins") -> ListsResponse:
+    async def get_items(
+        self, xuid: str, listname: str = "XBLPins", **kwargs
+    ) -> ListsResponse:
         """
         Get items from specific list, defaults to "XBLPins"
 
@@ -43,12 +45,12 @@ class ListsProvider(BaseProvider):
             :class:`ListsResponse`: List Response
         """
         url = self.LISTS_URL + f"/users/xuid({xuid})/lists/PINS/{listname}"
-        resp = await self.client.session.get(url, headers=self.HEADERS_LISTS)
+        resp = await self.client.session.get(url, headers=self.HEADERS_LISTS, **kwargs)
         resp.raise_for_status()
         return ListsResponse.parse_raw(await resp.text())
 
     async def insert_items(
-        self, xuid: str, post_body: dict, listname: str = "XBLPins"
+        self, xuid: str, post_body: dict, listname: str = "XBLPins", **kwargs
     ) -> ListMetadata:
         """
         Insert items to specific list, defaults to "XBLPins"
@@ -62,7 +64,7 @@ class ListsProvider(BaseProvider):
         """
         url = self.LISTS_URL + f"/users/xuid({xuid})/lists/PINS/{listname}"
         resp = await self.client.session.post(
-            url, json=post_body, headers=self.HEADERS_LISTS
+            url, json=post_body, headers=self.HEADERS_LISTS, **kwargs
         )
         resp.raise_for_status()
         return ListMetadata.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/message/__init__.py
+++ b/xbox/webapi/api/provider/message/__init__.py
@@ -16,24 +16,22 @@ class MessageProvider(BaseProvider):
     HEADERS_MESSAGE = {"x-xbl-contract-version": "1"}
     HEADERS_HORIZON = {"x-xbl-contract-version": "2"}
 
-    async def get_inbox(self) -> InboxResponse:
+    async def get_inbox(self, **kwargs) -> InboxResponse:
         """
         Get messages
-
-        Args:
-            skip_items: Item count to skip
-            max_items: Maximum item count to load
 
         Returns:
             :class:`InboxResponse`: Inbox Response
         """
         url = f"{self.MSG_URL}/network/Xbox/users/me/inbox"
-        resp = await self.client.session.get(url, headers=self.HEADERS_MESSAGE)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_MESSAGE, **kwargs
+        )
         resp.raise_for_status()
         return InboxResponse.parse_raw(await resp.text())
 
     async def get_conversation(
-        self, xuid: str, max_items: int = 100
+        self, xuid: str, max_items: int = 100, **kwargs
     ) -> ConversationResponse:
         """
         Get detailed conversation info
@@ -47,12 +45,14 @@ class MessageProvider(BaseProvider):
         url = f"{self.MSG_URL}/network/Xbox/users/me/conversations/users/xuid({xuid})"
         params = {"maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_MESSAGE
+            url, params=params, headers=self.HEADERS_MESSAGE, **kwargs
         )
         resp.raise_for_status()
         return ConversationResponse.parse_raw(await resp.text())
 
-    async def delete_conversation(self, conversation_id: str, horizon: str) -> bool:
+    async def delete_conversation(
+        self, conversation_id: str, horizon: str, **kwargs
+    ) -> bool:
         """
         Delete message
 
@@ -76,11 +76,13 @@ class MessageProvider(BaseProvider):
             ]
         }
         resp = await self.client.session.put(
-            url, json=post_data, headers=self.HEADERS_HORIZON
+            url, json=post_data, headers=self.HEADERS_HORIZON, **kwargs
         )
         return resp.status == 200
 
-    async def delete_message(self, conversation_id: str, message_id: str) -> bool:
+    async def delete_message(
+        self, conversation_id: str, message_id: str, **kwargs
+    ) -> bool:
         """
         Delete message
 
@@ -93,10 +95,14 @@ class MessageProvider(BaseProvider):
         Returns: True on success, False otherwise
         """
         url = f"{self.MSG_URL}/network/Xbox/users/me/conversations/{conversation_id}/messages/{message_id}"
-        resp = await self.client.session.delete(url, headers=self.HEADERS_MESSAGE)
+        resp = await self.client.session.delete(
+            url, headers=self.HEADERS_MESSAGE, **kwargs
+        )
         return resp.status == 200
 
-    async def send_message(self, xuid: str, message_text: str) -> SendMessageResponse:
+    async def send_message(
+        self, xuid: str, message_text: str, **kwargs
+    ) -> SendMessageResponse:
         """
         Send message to an xuid
 
@@ -121,7 +127,7 @@ class MessageProvider(BaseProvider):
             ]
         }
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_MESSAGE
+            url, json=post_data, headers=self.HEADERS_MESSAGE, **kwargs
         )
         resp.raise_for_status()
         return SendMessageResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/message/models.py
+++ b/xbox/webapi/api/provider/message/models.py
@@ -7,7 +7,7 @@ from xbox.webapi.common.models import CamelCaseModel
 class Part(CamelCaseModel):
     content_type: str
     version: int
-    text: str
+    text: Optional[str]
     unsuitable_for: Optional[List]
     locator: Optional[str]
 

--- a/xbox/webapi/api/provider/people/__init__.py
+++ b/xbox/webapi/api/provider/people/__init__.py
@@ -33,7 +33,7 @@ class PeopleProvider(BaseProvider):
         self._headers.update({"Accept-Language": self.client.language.locale})
 
     async def get_friends_own(
-        self, decoration_fields: List[PeopleDecoration] = None
+        self, decoration_fields: List[PeopleDecoration] = None, **kwargs
     ) -> PeopleResponse:
         """
         Get friendlist of own profile
@@ -51,12 +51,12 @@ class PeopleProvider(BaseProvider):
         decoration = self.SEPERATOR.join(decoration_fields)
 
         url = f"{self.PEOPLE_URL}/users/me/people/social/decoration/{decoration}"
-        resp = await self.client.session.get(url, headers=self._headers)
+        resp = await self.client.session.get(url, headers=self._headers, **kwargs)
         resp.raise_for_status()
         return PeopleResponse.parse_raw(await resp.text())
 
     async def get_friends_by_xuid(
-        self, xuid: str, decoration_fields: List[PeopleDecoration] = None
+        self, xuid: str, decoration_fields: List[PeopleDecoration] = None, **kwargs
     ) -> PeopleResponse:
         """
         Get friendlist of own profile
@@ -74,12 +74,15 @@ class PeopleProvider(BaseProvider):
         decoration = self.SEPERATOR.join(decoration_fields)
 
         url = f"{self.PEOPLE_URL}/users/xuid({xuid})/people/social/decoration/{decoration}"
-        resp = await self.client.session.get(url, headers=self._headers)
+        resp = await self.client.session.get(url, headers=self._headers, **kwargs)
         resp.raise_for_status()
         return PeopleResponse.parse_raw(await resp.text())
 
     async def get_friends_own_batch(
-        self, xuids: List[str], decoration_fields: List[PeopleDecoration] = None
+        self,
+        xuids: List[str],
+        decoration_fields: List[PeopleDecoration] = None,
+        **kwargs,
     ) -> PeopleResponse:
         """
         Get friends metadata by providing a list of XUIDs
@@ -101,12 +104,12 @@ class PeopleProvider(BaseProvider):
 
         url = f"{self.PEOPLE_URL}/users/me/people/batch/decoration/{decoration}"
         resp = await self.client.session.post(
-            url, json={"xuids": xuids}, headers=self._headers
+            url, json={"xuids": xuids}, headers=self._headers, **kwargs
         )
         resp.raise_for_status()
         return PeopleResponse.parse_raw(await resp.text())
 
-    async def get_friend_recommendations(self) -> PeopleResponse:
+    async def get_friend_recommendations(self, **kwargs) -> PeopleResponse:
         """
         Get recommended friends
 
@@ -114,11 +117,11 @@ class PeopleProvider(BaseProvider):
             :class:`PeopleResponse`: People Response
         """
         url = f"{self.PEOPLE_URL}/users/me/people/recommendations"
-        resp = await self.client.session.get(url, headers=self._headers)
+        resp = await self.client.session.get(url, headers=self._headers, **kwargs)
         resp.raise_for_status()
         return PeopleResponse.parse_raw(await resp.text())
 
-    async def get_friends_summary_own(self) -> PeopleSummaryResponse:
+    async def get_friends_summary_own(self, **kwargs) -> PeopleSummaryResponse:
         """
         Get friendlist summary of own profile
 
@@ -126,11 +129,13 @@ class PeopleProvider(BaseProvider):
             :class:`PeopleSummaryResponse`: People Summary Response
         """
         url = self.SOCIAL_URL + "/users/me/summary"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL, **kwargs)
         resp.raise_for_status()
         return PeopleSummaryResponse.parse_raw(await resp.text())
 
-    async def get_friends_summary_by_xuid(self, xuid: str) -> PeopleSummaryResponse:
+    async def get_friends_summary_by_xuid(
+        self, xuid: str, **kwargs
+    ) -> PeopleSummaryResponse:
         """
         Get friendlist summary of user by xuid
 
@@ -141,12 +146,12 @@ class PeopleProvider(BaseProvider):
             :class:`PeopleSummaryResponse`: People Summary Response
         """
         url = self.SOCIAL_URL + f"/users/xuid({xuid})/summary"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL, **kwargs)
         resp.raise_for_status()
         return PeopleSummaryResponse.parse_raw(await resp.text())
 
     async def get_friends_summary_by_gamertag(
-        self, gamertag: str
+        self, gamertag: str, **kwargs
     ) -> PeopleSummaryResponse:
         """
         Get friendlist summary of user by gamertag
@@ -158,6 +163,6 @@ class PeopleProvider(BaseProvider):
             :class:`PeopleSummaryResponse`: People Summary Response
         """
         url = self.SOCIAL_URL + f"/users/gt({gamertag})/summary"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL)
+        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL, **kwargs)
         resp.raise_for_status()
         return PeopleSummaryResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/presence/__init__.py
+++ b/xbox/webapi/api/provider/presence/__init__.py
@@ -20,6 +20,7 @@ class PresenceProvider(BaseProvider):
         xuids: List[str],
         online_only: bool = False,
         presence_level: PresenceLevel = PresenceLevel.USER,
+        **kwargs,
     ) -> List[PresenceItem]:
         """
         Get presence for list of xuids
@@ -41,14 +42,14 @@ class PresenceProvider(BaseProvider):
             "level": presence_level,
         }
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_PRESENCE
+            url, json=post_data, headers=self.HEADERS_PRESENCE, **kwargs
         )
         resp.raise_for_status()
         parsed = PresenceBatchResponse.parse_raw(await resp.text())
         return parsed.__root__
 
     async def get_presence_own(
-        self, presence_level: PresenceLevel = PresenceLevel.ALL
+        self, presence_level: PresenceLevel = PresenceLevel.ALL, **kwargs
     ) -> PresenceItem:
         """
         Get presence of own profile
@@ -62,7 +63,7 @@ class PresenceProvider(BaseProvider):
         url = self.PRESENCE_URL + "/users/me"
         params = {"level": presence_level}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_PRESENCE
+            url, params=params, headers=self.HEADERS_PRESENCE, **kwargs
         )
         resp.raise_for_status()
         return PresenceItem.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/profile/__init__.py
+++ b/xbox/webapi/api/provider/profile/__init__.py
@@ -14,7 +14,7 @@ class ProfileProvider(BaseProvider):
     HEADERS_PROFILE = {"x-xbl-contract-version": "3"}
     SEPARATOR = ","
 
-    async def get_profiles(self, xuid_list: List[str]) -> ProfileResponse:
+    async def get_profiles(self, xuid_list: List[str], **kwargs) -> ProfileResponse:
         """
         Get profile info for list of xuids
 
@@ -45,12 +45,12 @@ class ProfileProvider(BaseProvider):
         }
         url = self.PROFILE_URL + "/users/batch/profile/settings"
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_PROFILE
+            url, json=post_data, headers=self.HEADERS_PROFILE, **kwargs
         )
         resp.raise_for_status()
         return ProfileResponse.parse_raw(await resp.text())
 
-    async def get_profile_by_xuid(self, target_xuid: str) -> ProfileResponse:
+    async def get_profile_by_xuid(self, target_xuid: str, **kwargs) -> ProfileResponse:
         """
         Get Userprofile by xuid
 
@@ -83,12 +83,12 @@ class ProfileProvider(BaseProvider):
             )
         }
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_PROFILE
+            url, params=params, headers=self.HEADERS_PROFILE, **kwargs
         )
         resp.raise_for_status()
         return ProfileResponse.parse_raw(await resp.text())
 
-    async def get_profile_by_gamertag(self, gamertag: str) -> ProfileResponse:
+    async def get_profile_by_gamertag(self, gamertag: str, **kwargs) -> ProfileResponse:
         """
         Get Userprofile by gamertag
 
@@ -121,7 +121,7 @@ class ProfileProvider(BaseProvider):
             )
         }
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_PROFILE
+            url, params=params, headers=self.HEADERS_PROFILE, **kwargs
         )
         resp.raise_for_status()
         return ProfileResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/screenshots/__init__.py
+++ b/xbox/webapi/api/provider/screenshots/__init__.py
@@ -10,7 +10,7 @@ class ScreenshotsProvider(BaseProvider):
     HEADERS_SCREENSHOTS_METADATA = {"x-xbl-contract-version": "5"}
 
     async def get_recent_community_screenshots_by_title_id(
-        self, title_id: str
+        self, title_id: str, **kwargs
     ) -> ScreenshotResponse:
         """
         Get recent community screenshots by Title Id
@@ -24,13 +24,13 @@ class ScreenshotsProvider(BaseProvider):
         url = self.SCREENSHOTS_METADATA_URL + f"/public/titles/{title_id}/screenshots"
         params = {"qualifier": "created"}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA
+            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return ScreenshotResponse.parse_raw(await resp.text())
 
     async def get_recent_own_screenshots(
-        self, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self, title_id: str = None, skip_items: int = 0, max_items: int = 25, **kwargs
     ) -> ScreenshotResponse:
         """
         Get own recent screenshots, optionally filter for title Id
@@ -50,13 +50,18 @@ class ScreenshotsProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA
+            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return ScreenshotResponse.parse_raw(await resp.text())
 
     async def get_recent_screenshots_by_xuid(
-        self, xuid: str, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self,
+        xuid: str,
+        title_id: str = None,
+        skip_items: int = 0,
+        max_items: int = 25,
+        **kwargs,
     ) -> ScreenshotResponse:
         """
         Get recent screenshots by XUID, optionally filter for title Id
@@ -77,13 +82,13 @@ class ScreenshotsProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA
+            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return ScreenshotResponse.parse_raw(await resp.text())
 
     async def get_saved_community_screenshots_by_title_id(
-        self, title_id: str
+        self, title_id: str, **kwargs
     ) -> ScreenshotResponse:
         """
         Get saved community screenshots by Title Id
@@ -97,13 +102,13 @@ class ScreenshotsProvider(BaseProvider):
         url = f"{self.SCREENSHOTS_METADATA_URL}/public/titles/{title_id}/screenshots/saved"
         params = {"qualifier": "created"}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA
+            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return ScreenshotResponse.parse_raw(await resp.text())
 
     async def get_saved_own_screenshots(
-        self, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self, title_id: str = None, skip_items: int = 0, max_items: int = 25, **kwargs
     ) -> ScreenshotResponse:
         """
         Get own saved screenshots, optionally filter for title Id an
@@ -123,13 +128,18 @@ class ScreenshotsProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA
+            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return ScreenshotResponse.parse_raw(await resp.text())
 
     async def get_saved_screenshots_by_xuid(
-        self, xuid: str, title_id: str = None, skip_items: int = 0, max_items: int = 25
+        self,
+        xuid: str,
+        title_id: str = None,
+        skip_items: int = 0,
+        max_items: int = 25,
+        **kwargs,
     ) -> ScreenshotResponse:
         """
         Get saved screenshots by XUID, optionally filter for title Id
@@ -150,7 +160,7 @@ class ScreenshotsProvider(BaseProvider):
 
         params = {"skipItems": skip_items, "maxItems": max_items}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA
+            url, params=params, headers=self.HEADERS_SCREENSHOTS_METADATA, **kwargs
         )
         resp.raise_for_status()
         return ScreenshotResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/smartglass/__init__.py
+++ b/xbox/webapi/api/provider/smartglass/__init__.py
@@ -37,7 +37,7 @@ class SmartglassProvider(BaseProvider):
         self._smartglass_session_id = str(uuid4())
 
     async def get_console_list(
-        self, include_storage_devices: bool = True
+        self, include_storage_devices: bool = True, **kwargs
     ) -> SmartglassConsoleList:
         """
         Get Console list
@@ -51,11 +51,11 @@ class SmartglassProvider(BaseProvider):
             "queryCurrentDevice": "false",
             "includeStorageDevices": str(include_storage_devices).lower(),
         }
-        resp = await self._fetch_list("devices", params)
+        resp = await self._fetch_list("devices", params, **kwargs)
         return SmartglassConsoleList.parse_raw(await resp.text())
 
     async def get_installed_apps(
-        self, device_id: Optional[str] = None
+        self, device_id: Optional[str] = None, **kwargs
     ) -> InstalledPackagesList:
         """
         Get Installed Apps
@@ -68,10 +68,10 @@ class SmartglassProvider(BaseProvider):
         params = {}
         if device_id:
             params["deviceId"] = device_id
-        resp = await self._fetch_list("installedApps", params)
+        resp = await self._fetch_list("installedApps", params, **kwargs)
         return InstalledPackagesList.parse_raw(await resp.text())
 
-    async def get_storage_devices(self, device_id: str) -> StorageDevicesList:
+    async def get_storage_devices(self, device_id: str, **kwargs) -> StorageDevicesList:
         """
         Get Installed Apps
 
@@ -81,10 +81,12 @@ class SmartglassProvider(BaseProvider):
         Returns: Storage Devices list
         """
         params = {"deviceId": device_id}
-        resp = await self._fetch_list("storageDevices", params)
+        resp = await self._fetch_list("storageDevices", params, **kwargs)
         return StorageDevicesList.parse_raw(await resp.text())
 
-    async def get_console_status(self, device_id: str) -> SmartglassConsoleStatus:
+    async def get_console_status(
+        self, device_id: str, **kwargs
+    ) -> SmartglassConsoleStatus:
         """
         Get Console Status
 
@@ -94,12 +96,12 @@ class SmartglassProvider(BaseProvider):
         Returns: Console Status
         """
         url = f"{self.SG_URL}/consoles/{device_id}"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SG)
+        resp = await self.client.session.get(url, headers=self.HEADERS_SG, **kwargs)
         resp.raise_for_status()
         return SmartglassConsoleStatus.parse_raw(await resp.text())
 
     async def get_op_status(
-        self, device_id: str, op_id: str
+        self, device_id: str, op_id: str, **kwargs
     ) -> OperationStatusResponse:
         """
         Get Operation Status
@@ -116,11 +118,11 @@ class SmartglassProvider(BaseProvider):
             "x-xbl-opId": op_id,
             "x-xbl-deviceId": device_id,
         }
-        resp = await self.client.session.get(url, headers=headers)
+        resp = await self.client.session.get(url, headers=headers, **kwargs)
         resp.raise_for_status()
         return OperationStatusResponse.parse_raw(await resp.text())
 
-    async def wake_up(self, device_id: str) -> CommandResponse:
+    async def wake_up(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Wake Up Console
 
@@ -129,9 +131,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Power", "WakeUp")
+        return await self._send_one_shot_command(device_id, "Power", "WakeUp", **kwargs)
 
-    async def turn_off(self, device_id: str) -> CommandResponse:
+    async def turn_off(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Turn Off Console
 
@@ -140,9 +142,11 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Power", "TurnOff")
+        return await self._send_one_shot_command(
+            device_id, "Power", "TurnOff", **kwargs
+        )
 
-    async def reboot(self, device_id: str) -> CommandResponse:
+    async def reboot(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Reboot Console
 
@@ -151,9 +155,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Power", "Reboot")
+        return await self._send_one_shot_command(device_id, "Power", "Reboot", **kwargs)
 
-    async def mute(self, device_id: str) -> CommandResponse:
+    async def mute(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Mute
 
@@ -162,9 +166,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Audio", "Mute")
+        return await self._send_one_shot_command(device_id, "Audio", "Mute", **kwargs)
 
-    async def unmute(self, device_id: str) -> CommandResponse:
+    async def unmute(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Unmute
 
@@ -173,10 +177,10 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Audio", "Unmute")
+        return await self._send_one_shot_command(device_id, "Audio", "Unmute", **kwargs)
 
     async def volume(
-        self, device_id: str, direction: VolumeDirection, amount: int = 1
+        self, device_id: str, direction: VolumeDirection, amount: int = 1, **kwargs
     ) -> CommandResponse:
         """
         Adjust Volume
@@ -187,9 +191,11 @@ class SmartglassProvider(BaseProvider):
         Returns: Command Response
         """
         params = [{"direction": direction.value, "amount": str(amount)}]
-        return await self._send_one_shot_command(device_id, "Audio", "Volume", params)
+        return await self._send_one_shot_command(
+            device_id, "Audio", "Volume", params, **kwargs
+        )
 
-    async def play(self, device_id: str) -> CommandResponse:
+    async def play(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Play (media controls)
 
@@ -198,9 +204,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Media", "Play")
+        return await self._send_one_shot_command(device_id, "Media", "Play", **kwargs)
 
-    async def pause(self, device_id: str) -> CommandResponse:
+    async def pause(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Pause (media controls)
 
@@ -209,9 +215,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Media", "Pause")
+        return await self._send_one_shot_command(device_id, "Media", "Pause", **kwargs)
 
-    async def previous(self, device_id: str) -> CommandResponse:
+    async def previous(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Previous (media controls)
 
@@ -220,9 +226,11 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Media", "Previous")
+        return await self._send_one_shot_command(
+            device_id, "Media", "Previous", **kwargs
+        )
 
-    async def next(self, device_id: str) -> CommandResponse:
+    async def next(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Next (media controls)
 
@@ -231,9 +239,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Media", "Next")
+        return await self._send_one_shot_command(device_id, "Media", "Next", **kwargs)
 
-    async def go_home(self, device_id: str) -> CommandResponse:
+    async def go_home(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Go Home
 
@@ -242,9 +250,9 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Shell", "GoHome")
+        return await self._send_one_shot_command(device_id, "Shell", "GoHome", **kwargs)
 
-    async def go_back(self, device_id: str) -> CommandResponse:
+    async def go_back(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Go Back
 
@@ -254,10 +262,10 @@ class SmartglassProvider(BaseProvider):
         Returns:
             :class:`SmartglassConsoleStatus`: Command Response
         """
-        return await self._send_one_shot_command(device_id, "Shell", "GoBack")
+        return await self._send_one_shot_command(device_id, "Shell", "GoBack", **kwargs)
 
     async def show_guide_tab(
-        self, device_id: str, tab: GuideTab = GuideTab.Guide
+        self, device_id: str, tab: GuideTab = GuideTab.Guide, **kwargs
     ) -> CommandResponse:
         """
         Show Guide Tab
@@ -269,11 +277,11 @@ class SmartglassProvider(BaseProvider):
         """
         params = [{"tabName": tab.value}]
         return await self._send_one_shot_command(
-            device_id, "Shell", "ShowGuideTab", params
+            device_id, "Shell", "ShowGuideTab", params, **kwargs
         )
 
     async def press_button(
-        self, device_id: str, button: InputKeyType
+        self, device_id: str, button: InputKeyType, **kwargs
     ) -> CommandResponse:
         """
         Press Button
@@ -285,10 +293,10 @@ class SmartglassProvider(BaseProvider):
         """
         params = [{"keyType": button.value}]
         return await self._send_one_shot_command(
-            device_id, "Shell", "InjectKey", params
+            device_id, "Shell", "InjectKey", params, **kwargs
         )
 
-    async def insert_text(self, device_id: str, text: str) -> CommandResponse:
+    async def insert_text(self, device_id: str, text: str, **kwargs) -> CommandResponse:
         """
         Insert Text
 
@@ -299,11 +307,11 @@ class SmartglassProvider(BaseProvider):
         """
         params = [{"replacementString": text}]
         return await self._send_one_shot_command(
-            device_id, "Shell", "InjectString", params
+            device_id, "Shell", "InjectString", params, **kwargs
         )
 
     async def launch_app(
-        self, device_id: str, one_store_product_id: str
+        self, device_id: str, one_store_product_id: str, **kwargs
     ) -> CommandResponse:
         """
         Launch Application
@@ -316,10 +324,14 @@ class SmartglassProvider(BaseProvider):
         """
         params = [{"oneStoreProductId": one_store_product_id}]
         return await self._send_one_shot_command(
-            device_id, "Shell", "ActivateApplicationWithOneStoreProductId", params
+            device_id,
+            "Shell",
+            "ActivateApplicationWithOneStoreProductId",
+            params,
+            **kwargs,
         )
 
-    async def show_tv_guide(self, device_id: str) -> CommandResponse:
+    async def show_tv_guide(self, device_id: str, **kwargs) -> CommandResponse:
         """
         Show TV Guide
 
@@ -328,10 +340,10 @@ class SmartglassProvider(BaseProvider):
 
         Returns: Command Response
         """
-        return await self._send_one_shot_command(device_id, "TV", "ShowGuide")
+        return await self._send_one_shot_command(device_id, "TV", "ShowGuide", **kwargs)
 
     async def _fetch_list(
-        self, list_name: str, params: Optional[dict] = None
+        self, list_name: str, params: Optional[dict] = None, **kwargs
     ) -> ClientResponse:
         """
         Fetch arbitrary list
@@ -345,7 +357,7 @@ class SmartglassProvider(BaseProvider):
         """
         url = f"{self.SG_URL}/lists/{list_name}"
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_SG
+            url, params=params, headers=self.HEADERS_SG, **kwargs
         )
         resp.raise_for_status()
         return resp
@@ -356,6 +368,7 @@ class SmartglassProvider(BaseProvider):
         command_type: str,
         command: str,
         params: Optional[List[dict]] = None,
+        **kwargs,
     ) -> CommandResponse:
         """
         Send One Shot command to console
@@ -378,6 +391,8 @@ class SmartglassProvider(BaseProvider):
             "parameters": params or [{}],
             "linkedXboxId": device_id,
         }
-        resp = await self.client.session.post(url, json=body, headers=self.HEADERS_SG)
+        resp = await self.client.session.post(
+            url, json=body, headers=self.HEADERS_SG, **kwargs
+        )
         resp.raise_for_status()
         return CommandResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/smartglass/__init__.py
+++ b/xbox/webapi/api/provider/smartglass/__init__.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from aiohttp import ClientResponse
 
+from xbox.webapi.api.client import XboxLiveClient
 from xbox.webapi.api.provider.baseprovider import BaseProvider
 from xbox.webapi.api.provider.smartglass.models import (
     CommandResponse,
@@ -27,12 +28,11 @@ class SmartglassProvider(BaseProvider):
         "skillplatform": "RemoteManagement",
     }
 
-    def __init__(self, client):
+    def __init__(self, client: XboxLiveClient):
         """
         Initialize Baseclass, create smartglass session id
 
-        Args:
-            client (:class:`XboxLiveClient`): Instance of client
+        Args: Instance of XBL client
         """
         super().__init__(client)
         self._smartglass_session_id = str(uuid4())
@@ -46,8 +46,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             include_storage_devices: Include a list of storage devices in the response
 
-        Returns:
-            :class:`SmartglassConsoleList`: Console List
+        Returns: Console List
         """
         params = {
             "queryCurrentDevice": "false",
@@ -65,8 +64,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`InstalledPackagesList`: Installed Apps
+        Returns: Installed Apps
         """
         params = {}
         if device_id:
@@ -81,8 +79,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`StorageDevicesList`: Storage Devices
+        Returns: Storage Devices list
         """
         params = {"deviceId": device_id}
         resp = await self._fetch_list("storageDevices", params)
@@ -95,8 +92,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Console Status
+        Returns: Console Status
         """
         url = f"{self.SG_URL}/consoles/{device_id}"
         resp = await self.client.session.get(url, headers=self.HEADERS_SG)
@@ -113,8 +109,7 @@ class SmartglassProvider(BaseProvider):
             device_id: ID of console (from console list)
             op_id: Operation ID (from previous command)
 
-        Returns:
-            :class:`OperationStatusResponse`: Operation Status
+        Returns: Operation Status
         """
         url = f"{self.SG_URL}/opStatus"
         headers = {
@@ -133,8 +128,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Power", "WakeUp")
 
@@ -145,8 +139,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Power", "TurnOff")
 
@@ -157,8 +150,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Power", "Reboot")
 
@@ -169,8 +161,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Audio", "Mute")
 
@@ -181,8 +172,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Audio", "Unmute")
 
@@ -195,8 +185,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         params = [{"direction": direction.value, "amount": str(amount)}]
         return await self._send_one_shot_command(device_id, "Audio", "Volume", params)
@@ -208,8 +197,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Media", "Play")
 
@@ -220,8 +208,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Media", "Pause")
 
@@ -232,8 +219,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Media", "Previous")
 
@@ -244,8 +230,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Media", "Next")
 
@@ -256,8 +241,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "Shell", "GoHome")
 
@@ -282,8 +266,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         params = [{"tabName": tab.value}]
         return await self._send_one_shot_command(
@@ -299,8 +282,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         params = [{"keyType": button.value}]
         return await self._send_one_shot_command(
@@ -314,8 +296,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         params = [{"replacementString": text}]
         return await self._send_one_shot_command(
@@ -332,8 +313,7 @@ class SmartglassProvider(BaseProvider):
             device_id: ID of console (from console list)
             one_store_product_id: OneStoreProductID for the app to launch
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         params = [{"oneStoreProductId": one_store_product_id}]
         return await self._send_one_shot_command(
@@ -347,8 +327,7 @@ class SmartglassProvider(BaseProvider):
         Args:
             device_id: ID of console (from console list)
 
-        Returns:
-            :class:`SmartglassConsoleStatus`: Command Response
+        Returns: Command Response
         """
         return await self._send_one_shot_command(device_id, "TV", "ShowGuide")
 
@@ -388,8 +367,7 @@ class SmartglassProvider(BaseProvider):
             command: name of command
             params: command parameters
 
-        Returns:
-            :class:`CommandResponse`: Command Response
+        Returns: Command Response
         """
         url = f"{self.SG_URL}/commands"
         body = {

--- a/xbox/webapi/api/provider/smartglass/__init__.py
+++ b/xbox/webapi/api/provider/smartglass/__init__.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 from aiohttp import ClientResponse
 
-from xbox.webapi.api.client import XboxLiveClient
 from xbox.webapi.api.provider.baseprovider import BaseProvider
 from xbox.webapi.api.provider.smartglass.models import (
     CommandResponse,
@@ -28,7 +27,7 @@ class SmartglassProvider(BaseProvider):
         "skillplatform": "RemoteManagement",
     }
 
-    def __init__(self, client: XboxLiveClient):
+    def __init__(self, client):
         """
         Initialize Baseclass, create smartglass session id
 

--- a/xbox/webapi/api/provider/titlehub/__init__.py
+++ b/xbox/webapi/api/provider/titlehub/__init__.py
@@ -32,6 +32,7 @@ class TitlehubProvider(BaseProvider):
         xuid: str,
         fields: Optional[List[TitleFields]] = None,
         max_items: Optional[int] = 5,
+        **kwargs,
     ) -> TitleHubResponse:
         """
         Get recently played titles
@@ -54,12 +55,14 @@ class TitlehubProvider(BaseProvider):
 
         url = f"{self.TITLEHUB_URL}/users/xuid({xuid})/titles/titlehistory/decoration/{fields}"
         params = {"maxItems": max_items}
-        resp = await self.client.session.get(url, params=params, headers=self._headers)
+        resp = await self.client.session.get(
+            url, params=params, headers=self._headers, **kwargs
+        )
         resp.raise_for_status()
         return TitleHubResponse.parse_raw(await resp.text())
 
     async def get_title_info(
-        self, title_id: str, fields: Optional[List[TitleFields]] = None
+        self, title_id: str, fields: Optional[List[TitleFields]] = None, **kwargs
     ) -> TitleHubResponse:
         """
         Get info for specific title
@@ -82,12 +85,12 @@ class TitlehubProvider(BaseProvider):
         fields = self.SEPARATOR.join(fields)
 
         url = f"{self.TITLEHUB_URL}/users/xuid({self.client.xuid})/titles/titleid({title_id})/decoration/{fields}"
-        resp = await self.client.session.get(url, headers=self._headers)
+        resp = await self.client.session.get(url, headers=self._headers, **kwargs)
         resp.raise_for_status()
         return TitleHubResponse.parse_raw(await resp.text())
 
     async def get_titles_batch(
-        self, pfns: List[str], fields: Optional[List[TitleFields]] = None
+        self, pfns: List[str], fields: Optional[List[TitleFields]] = None, **kwargs
     ) -> TitleHubResponse:
         """
         Get Title info via PFN ids
@@ -111,7 +114,7 @@ class TitlehubProvider(BaseProvider):
         url = self.TITLEHUB_URL + f"/titles/batch/decoration/{fields}"
         post_data = {"pfns": pfns, "windowsPhoneProductIds": []}
         resp = await self.client.session.post(
-            url, json=post_data, headers=self._headers
+            url, json=post_data, headers=self._headers, **kwargs
         )
         resp.raise_for_status()
         return TitleHubResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/usersearch/__init__.py
+++ b/xbox/webapi/api/provider/usersearch/__init__.py
@@ -9,7 +9,7 @@ class UserSearchProvider(BaseProvider):
     USERSEARCH_URL = "https://usersearch.xboxlive.com"
     HEADERS_USER_SEARCH = {"x-xbl-contract-version": "1"}
 
-    async def get_live_search(self, query: str) -> UserSearchResponse:
+    async def get_live_search(self, query: str, **kwargs) -> UserSearchResponse:
         """
         Get userprofiles for search query
 
@@ -22,7 +22,7 @@ class UserSearchProvider(BaseProvider):
         url = self.USERSEARCH_URL + "/suggest"
         params = {"q": query}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_USER_SEARCH
+            url, params=params, headers=self.HEADERS_USER_SEARCH, **kwargs
         )
         resp.raise_for_status()
         return UserSearchResponse.parse_raw(await resp.text())

--- a/xbox/webapi/api/provider/userstats/__init__.py
+++ b/xbox/webapi/api/provider/userstats/__init__.py
@@ -21,6 +21,7 @@ class UserStatsProvider(BaseProvider):
         xuid: str,
         service_config_id: str,
         stats_fields: Optional[List[GeneralStatsField]] = None,
+        **kwargs,
     ) -> UserStatsResponse:
         """
         Get userstats
@@ -38,7 +39,9 @@ class UserStatsProvider(BaseProvider):
         stats = self.SEPERATOR.join(stats_fields)
 
         url = f"{self.USERSTATS_URL}/users/xuid({xuid})/scids/{service_config_id}/stats/{stats}"
-        resp = await self.client.session.get(url, headers=self.HEADERS_USERSTATS)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_USERSTATS, **kwargs
+        )
         resp.raise_for_status()
         return UserStatsResponse.parse_raw(await resp.text())
 
@@ -47,6 +50,7 @@ class UserStatsProvider(BaseProvider):
         xuid: str,
         service_config_id: str,
         stats_fields: Optional[List[GeneralStatsField]] = None,
+        **kwargs,
     ) -> UserStatsResponse:
         """
         Get userstats including metadata for each stat (if available)
@@ -66,7 +70,7 @@ class UserStatsProvider(BaseProvider):
         url = f"{self.USERSTATS_URL}/users/xuid({xuid})/scids/{service_config_id}/stats/{stats}"
         params = {"include": "valuemetadata"}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_USERSTATS_WITH_METADATA
+            url, params=params, headers=self.HEADERS_USERSTATS_WITH_METADATA, **kwargs
         )
         resp.raise_for_status()
         return UserStatsResponse.parse_raw(await resp.text())
@@ -76,6 +80,7 @@ class UserStatsProvider(BaseProvider):
         xuids: List[str],
         title_id: str,
         stats_fields: Optional[List[GeneralStatsField]] = None,
+        **kwargs,
     ) -> UserStatsResponse:
         """
         Get userstats in batch mode
@@ -99,7 +104,7 @@ class UserStatsProvider(BaseProvider):
             "xuids": xuids,
         }
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_USERSTATS
+            url, json=post_data, headers=self.HEADERS_USERSTATS, **kwargs
         )
         resp.raise_for_status()
         return UserStatsResponse.parse_raw(await resp.text())
@@ -109,6 +114,7 @@ class UserStatsProvider(BaseProvider):
         xuids: List[str],
         service_config_id: str,
         stats_fields: Optional[List[GeneralStatsField]] = None,
+        **kwargs,
     ) -> UserStatsResponse:
         """
         Get userstats in batch mode, via scid
@@ -133,7 +139,7 @@ class UserStatsProvider(BaseProvider):
             "xuids": xuids,
         }
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_USERSTATS
+            url, json=post_data, headers=self.HEADERS_USERSTATS, **kwargs
         )
         resp.raise_for_status()
         return UserStatsResponse.parse_raw(await resp.text())

--- a/xbox/webapi/authentication/models.py
+++ b/xbox/webapi/authentication/models.py
@@ -86,7 +86,7 @@ class OAuth2TokenResponse(BaseModel):
     expires_in: int
     scope: str
     access_token: str
-    refresh_token: str
+    refresh_token: Optional[str]
     user_id: str
     issued: datetime = Field(default_factory=utc_now)
 

--- a/xbox/webapi/authentication/models.py
+++ b/xbox/webapi/authentication/models.py
@@ -20,6 +20,23 @@ class XTokenResponse(PascalCaseModel):
         return self.not_after > utc_now()
 
 
+class XADDisplayClaims(BaseModel):
+    # {"xdi": {"did": "F.....", "dcs": "0"}}
+    xdi: Dict[str, str]
+
+
+class XADResponse(XTokenResponse):
+    display_claims: XADDisplayClaims
+
+
+class XATDisplayClaims(BaseModel):
+    xti: Dict[str, str]
+
+
+class XATResponse(XTokenResponse):
+    display_claims: XATDisplayClaims
+
+
 class XAUDisplayClaims(BaseModel):
     xui: List[Dict[str, str]]
 


### PR DESCRIPTION
* Add models for XAD and XAT Token responses
* Fix message.get_inbox() (Setting text field as Optional) (Fixes issue #37)
* Fix OAuth2TokenResponse incase no refresh_token is returned by authentication (Fixes issue #36)
* Fix pytest warnings (unclosed ClientSession, usage of deprecated ClientResponse field)
* Fix CatalogResponse.Products[].DisplaySkuAvailabilities[].Availabilities - Set order_management_data as Optional
* Enable passing extra values to headers, params and data for all providers via kwargs (extra_headers, extra_params, extra_data)
* Fix GameclipsResponse