### PR TITLE
Updated Presence Api

### DIFF
--- a/xbox/webapi/api/provider/presence/models.py
+++ b/xbox/webapi/api/provider/presence/models.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import List, Optional
-
 from xbox.webapi.common.models import CamelCaseModel
-
 
 class PresenceLevel(str, Enum):
     USER = "user"
@@ -16,13 +14,30 @@ class LastSeen(CamelCaseModel):
     title_id: str
     title_name: str
     timestamp: str
+    
+class ActivityRecord(CamelCaseModel):
+    richPresence: str
+    media: str
+    
+class TitleRecord(CamelCaseModel):
+    id: str
+    name: str
+    activity: Optional[List[ActivityRecord]]
+    lastModified: str
+    placement: str
+    state: str
 
+class DeviceRecord(CamelCaseModel):
+    titles: List[TitleRecord]
+    type: str
+        
 
 class PresenceItem(CamelCaseModel):
     xuid: str
     state: str
     last_seen: Optional[LastSeen]
-
+    devices: Optional[List[DeviceRecord]]
+    
 
 class PresenceBatchResponse(CamelCaseModel):
     __root__: List[PresenceItem]

--- a/xbox/webapi/api/provider/presence/models.py
+++ b/xbox/webapi/api/provider/presence/models.py
@@ -16,20 +16,20 @@ class LastSeen(CamelCaseModel):
     timestamp: str
     
 class ActivityRecord(CamelCaseModel):
-    richPresence: str
-    media: str
+    richPresence: Optional[str]
+    media: Optional[str]
     
 class TitleRecord(CamelCaseModel):
-    id: str
-    name: str
+    id: Optional[str]
+    name: Optional[str]
     activity: Optional[List[ActivityRecord]]
-    lastModified: str
-    placement: str
-    state: str
+    lastModified: Optional[str]
+    placement: Optional[str]
+    state: Optional[str]
 
 class DeviceRecord(CamelCaseModel):
-    titles: List[TitleRecord]
-    type: str
+    titles: Optional[List[TitleRecord]]
+    type: Optional[str]
         
 
 class PresenceItem(CamelCaseModel):


### PR DESCRIPTION
Now the provider will print the user the Device Record in a clean print.

Example:
`
devices=[DeviceRecord(titles=[TitleRecord(id='750323071', name='', activity=None, lastModified='2021-05-07T21:50:47.7329203Z', placement='Background', state='Active'), TitleRecord(id='342226876', name='', activity=None, lastModified='2021-05-07T21:50:47.7329203Z', placement='Full', state='Active')], type='Scarlett'), DeviceRecord(titles=[TitleRecord(id='1144039928', name='', activity=None, lastModified='2021-05-07T21:46:51.484922Z', placement='Full', state='Active')], type='Win32'), DeviceRecord(titles=[TitleRecord(id='1144039928', name='', activity=None, lastModified='2021-05-07T21:48:28.4841154Z', placement='Full', state='Active')], type='WindowsOneCore')]
`