### PR TITLE
Make colors optional. Some users don't have any values for these.

### DIFF
--- a/xbox/webapi/api/provider/people/models.py
+++ b/xbox/webapi/api/provider/people/models.py
@@ -64,9 +64,9 @@ class Follower(CamelCaseModel):
 
 
 class PreferredColor(CamelCaseModel):
-    primary_color: str
-    secondary_color: str
-    tertiary_color: str
+    primary_color: Optional[str]
+    secondary_color: Optional[str]
+    tertiary_color: Optional[str]
 
 
 class PresenceDetail(PascalCaseModel):


### PR DESCRIPTION
Several users I have encountered have None values set for their color options. I have made these optional in the PeopleResponse model to fix this. Sending fix upstream for consideration.