### PR TITLE
Add support for microsoft-defined rate limits

### DIFF
--- a/tests/test_ratelimits.py
+++ b/tests/test_ratelimits.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+from httpx import Response
+import pytest
+
+from tests.common import get_response_json
+
+from xbox.webapi.common.exceptions import RateLimitExceededException
+
+
+@pytest.mark.asyncio
+async def test_ratelimits_exceeded_burst_only(respx_mock, xbl_client):
+    async def make_request():
+        route = respx_mock.get("https://peoplehub.xboxlive.com").mock(
+            return_value=Response(200, json=get_response_json("people_friends_own"))
+        )
+        ret = await xbl_client.people.get_friends_own()
+
+        assert len(ret.people) == 2
+        assert route.called
+
+    # Record the start time to ensure that the timeouts are the correct length
+    start_time = datetime.now()
+
+    # Make as many requests as possible without exceeding
+    max_request_num = xbl_client.people.RATE_LIMITS["burst"]
+    for i in range(max_request_num):
+        await make_request()
+
+    # Make another request, ensure that it raises the exception.
+    with pytest.raises(RateLimitExceededException) as exception:
+        await make_request()
+
+    # Get the error instance from pytest
+    ex: RateLimitExceededException = exception.value
+
+    # Assert that the counter matches the max request num (should not have incremented above max value)
+    assert ex.rate_limit.get_counter() == max_request_num
+
+    # Get the timeout we were issued
+    try_again_in = ex.rate_limit.get_reset_after()
+
+    # Assert that the timeout is the correct length
+    delta: timedelta = try_again_in - start_time
+    assert delta.seconds == 15

--- a/tests/test_ratelimits.py
+++ b/tests/test_ratelimits.py
@@ -3,8 +3,72 @@ from httpx import Response
 import pytest
 
 from tests.common import get_response_json
+from xbox.webapi.api.provider.ratelimitedprovider import RateLimitedProvider
 
 from xbox.webapi.common.exceptions import RateLimitExceededException
+from xbox.webapi.common.ratelimits import CombinedRateLimit
+from xbox.webapi.common.ratelimits.models import TimePeriod
+
+
+def helper_test_combinedratelimit(
+    crl: CombinedRateLimit, burstLimit: int, sustainLimit: int
+):
+    burst = crl.get_limits_by_period(TimePeriod.BURST)
+    sustain = crl.get_limits_by_period(TimePeriod.SUSTAIN)
+
+    # These functions should return a list with one element
+    assert type(burst) == list
+    assert type(sustain) == list
+
+    assert len(burst) == 1
+    assert len(sustain) == 1
+
+    # Check that their limits are what we expect
+    assert burst[0].get_limit() == burstLimit
+    assert sustain[0].get_limit() == sustainLimit
+
+
+def test_ratelimitedprovider_rate_limits_same_rw_values(xbl_client):
+    class child_class(RateLimitedProvider):
+        RATE_LIMITS = {"burst": 1, "sustain": 2}
+
+    instance = child_class(xbl_client)
+
+    helper_test_combinedratelimit(instance.rate_limit_read, 1, 2)
+    helper_test_combinedratelimit(instance.rate_limit_write, 1, 2)
+
+
+def test_ratelimitedprovider_rate_limits_diff_rw_values(xbl_client):
+    class child_class(RateLimitedProvider):
+        RATE_LIMITS = {
+            "burst": {"read": 1, "write": 2},
+            "sustain": {"read": 3, "write": 4},
+        }
+
+    instance = child_class(xbl_client)
+
+    helper_test_combinedratelimit(instance.rate_limit_read, 1, 3)
+    helper_test_combinedratelimit(instance.rate_limit_write, 2, 4)
+
+
+def test_ratelimitedprovider_rate_limits_mixed(xbl_client):
+    class burst_diff(RateLimitedProvider):
+        RATE_LIMITS = {"burst": {"read": 1, "write": 2}, "sustain": 3}
+
+    burst_diff_inst = burst_diff(xbl_client)
+
+    # Sustain values are the same (third paramater)
+    helper_test_combinedratelimit(burst_diff_inst.rate_limit_read, 1, 3)
+    helper_test_combinedratelimit(burst_diff_inst.rate_limit_write, 2, 3)
+
+    class sustain_diff(RateLimitedProvider):
+        RATE_LIMITS = {"burst": 4, "sustain": {"read": 5, "write": 6}}
+
+    sustain_diff_inst = sustain_diff(xbl_client)
+
+    # Burst values are the same (second paramater)
+    helper_test_combinedratelimit(sustain_diff_inst.rate_limit_read, 4, 5)
+    helper_test_combinedratelimit(sustain_diff_inst.rate_limit_write, 4, 6)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ratelimits.py
+++ b/tests/test_ratelimits.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from httpx import Response
 import pytest
+import asyncio
 
 from tests.common import get_response_json
 from xbox.webapi.api.provider.ratelimitedprovider import RateLimitedProvider
@@ -137,4 +138,104 @@ async def test_ratelimits_exceeded_burst_only(respx_mock, xbl_client):
 
     # Assert that the timeout is the correct length
     delta: timedelta = try_again_in - start_time
-    assert delta.seconds == 15
+    assert delta.seconds == TimePeriod.BURST.value  # 15 seconds
+
+
+async def helper_reach_and_wait_for_burst(
+    make_request, start_time, burst_limit: int, expected_counter: int
+):
+    # Make as many requests as possible without exceeding the BURST limit.
+    for i in range(burst_limit):
+        await make_request()
+
+    # Make another request, ensure that it raises the exception.
+    with pytest.raises(RateLimitExceededException) as exception:
+        await make_request()
+
+    # Get the error instance from pytest
+    ex: RateLimitExceededException = exception.value
+
+    # Assert that the counter matches the what we expect (burst, 2x burstm etc)
+    assert ex.rate_limit.get_counter() == expected_counter
+
+    # Get the reset_after value
+    # (if we call it after waiting for it to expire the function will return None)
+    burst_resets_after = ex.rate_limit.get_reset_after()
+
+    # Wait for the burst limit timeout to elapse.
+    await asyncio.sleep(TimePeriod.BURST.value)  # 15 seconds
+
+    # Assert that the reset_after value has passed.
+    assert burst_resets_after < datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_ratelimits_exceeded_sustain_only(respx_mock, xbl_client):
+    async def make_request():
+        route = respx_mock.get("https://social.xboxlive.com").mock(
+            return_value=Response(200, json=get_response_json("people_summary_own"))
+        )
+        ret = await xbl_client.people.get_friends_summary_own()
+
+        assert route.called
+
+    # Record the start time to ensure that the timeouts are the correct length
+    start_time = datetime.now()
+
+    # Get the max requests for this route.
+    max_request_num = xbl_client.people.RATE_LIMITS["sustain"]  # 30
+    burst_max_request_num = xbl_client.people.RATE_LIMITS["burst"]  # 10
+
+    # In this case, the BURST limit is three times that of SUSTAIN, so we need to exceed the burst limit three times.
+
+    # Exceed the burst limit and wait for it to reset (10 requests)
+    await helper_reach_and_wait_for_burst(
+        make_request, start_time, burst_limit=burst_max_request_num, expected_counter=10
+    )
+
+    # Repeat: Exceed the burst limit and wait for it to reset (10 requests)
+    # Counter (the sustain one will be returned)
+    #         For (CombinedRateLimit).get_counter(), the highest counter is returned. (sustain in this case)
+    await helper_reach_and_wait_for_burst(
+        make_request, start_time, burst_limit=burst_max_request_num, expected_counter=20
+    )
+
+    # Now, make the rest of the requests (10 left, 20/30 done!)
+    for i in range(10):
+        await make_request()
+
+    # Wait for the burst limit to 'reset'.
+    await asyncio.sleep(TimePeriod.BURST.value)  # 15 seconds
+
+    # Now, we have made 30 requests.
+    # The counters should be as follows:
+    # - BURST: 0* (will reset on next check)
+    # - SUSTAIN: 30
+    # The next request we make should exceed the SUSTAIN rate limit.
+
+    # Make another request, ensure that it raises the exception.
+    with pytest.raises(RateLimitExceededException) as exception:
+        await make_request()
+
+    # Get the error instance from pytest
+    ex: RateLimitExceededException = exception.value
+
+    # Get the SingleRateLimit objects from the exception
+    rl: CombinedRateLimit = ex.rate_limit
+    burst = rl.get_limits_by_period(TimePeriod.BURST)[0]
+    sustain = rl.get_limits_by_period(TimePeriod.SUSTAIN)[0]
+
+    # Assert that we have only exceeded the sustain limit.
+    assert not burst.is_exceeded()
+    assert sustain.is_exceeded()
+
+    # Assert that the counter matches the max request num (should not have incremented above max value)
+    assert ex.rate_limit.get_counter() == max_request_num
+
+    # Get the timeout we were issued
+    try_again_in = ex.rate_limit.get_reset_after()
+
+    # Assert that the timeout is the correct length
+    # The SUSTAIN counter has not been reset during this test, so the try again in should be 300 seconds since we started this test.
+    delta: timedelta = try_again_in - start_time
+    assert delta.seconds == TimePeriod.SUSTAIN.value  # 300 seconds (5 minutes)

--- a/tests/test_ratelimits.py
+++ b/tests/test_ratelimits.py
@@ -107,12 +107,11 @@ def test_ratelimitedprovider_rate_limits_incorrect_key_type(xbl_client):
 @pytest.mark.asyncio
 async def test_ratelimits_exceeded_burst_only(respx_mock, xbl_client):
     async def make_request():
-        route = respx_mock.get("https://peoplehub.xboxlive.com").mock(
-            return_value=Response(200, json=get_response_json("people_friends_own"))
+        route = respx_mock.get("https://social.xboxlive.com").mock(
+            return_value=Response(200, json=get_response_json("people_summary_own"))
         )
-        ret = await xbl_client.people.get_friends_own()
+        ret = await xbl_client.people.get_friends_summary_own()
 
-        assert len(ret.people) == 2
         assert route.called
 
     # Record the start time to ensure that the timeouts are the correct length

--- a/xbox/webapi/api/client.py
+++ b/xbox/webapi/api/client.py
@@ -88,9 +88,14 @@ class Session:
             if rate_limits.is_exceeded():
                 raise RateLimitExceededException("Rate limit exceeded", rate_limits)
 
-        return await self._auth_mgr.session.request(
+        response = await self._auth_mgr.session.request(
             method, url, **kwargs, headers=headers, params=params, data=data
         )
+
+        if rate_limits:
+            rate_limits.increment()
+
+        return response
 
     async def get(self, url: str, **kwargs: Any) -> Response:
         return await self.request("GET", url, **kwargs)

--- a/xbox/webapi/api/provider/achievements/__init__.py
+++ b/xbox/webapi/api/provider/achievements/__init__.py
@@ -9,13 +9,15 @@ from xbox.webapi.api.provider.achievements.models import (
     AchievementResponse,
     RecentProgressResponse,
 )
-from xbox.webapi.api.provider.baseprovider import BaseProvider
+from xbox.webapi.api.provider.ratelimitedprovider import RateLimitedProvider
 
 
-class AchievementsProvider(BaseProvider):
+class AchievementsProvider(RateLimitedProvider):
     ACHIEVEMENTS_URL = "https://achievements.xboxlive.com"
     HEADERS_GAME_360_PROGRESS = {"x-xbl-contract-version": "1"}
     HEADERS_GAME_PROGRESS = {"x-xbl-contract-version": "2"}
+
+    RATE_LIMITS = {"burst": 100, "sustain": 300}
 
     async def get_achievements_detail_item(
         self, xuid, service_config_id, achievement_id, **kwargs
@@ -33,7 +35,10 @@ class AchievementsProvider(BaseProvider):
         """
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/achievements/{service_config_id}/{achievement_id}"
         resp = await self.client.session.get(
-            url, headers=self.HEADERS_GAME_PROGRESS, **kwargs
+            url,
+            headers=self.HEADERS_GAME_PROGRESS,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return AchievementResponse(**resp.json())
@@ -54,7 +59,11 @@ class AchievementsProvider(BaseProvider):
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/titleachievements?"
         params = {"titleId": title_id}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAME_360_PROGRESS, **kwargs
+            url,
+            params=params,
+            headers=self.HEADERS_GAME_360_PROGRESS,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return Achievement360Response(**resp.json())
@@ -75,7 +84,11 @@ class AchievementsProvider(BaseProvider):
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/achievements?"
         params = {"titleId": title_id}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAME_360_PROGRESS, **kwargs
+            url,
+            params=params,
+            headers=self.HEADERS_GAME_360_PROGRESS,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return Achievement360Response(**resp.json())
@@ -94,7 +107,10 @@ class AchievementsProvider(BaseProvider):
         """
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/history/titles"
         resp = await self.client.session.get(
-            url, headers=self.HEADERS_GAME_360_PROGRESS, **kwargs
+            url,
+            headers=self.HEADERS_GAME_360_PROGRESS,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return Achievement360ProgressResponse(**resp.json())
@@ -115,7 +131,11 @@ class AchievementsProvider(BaseProvider):
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/achievements?"
         params = {"titleId": title_id}
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_GAME_PROGRESS, **kwargs
+            url,
+            params=params,
+            headers=self.HEADERS_GAME_PROGRESS,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return AchievementResponse(**resp.json())
@@ -134,7 +154,10 @@ class AchievementsProvider(BaseProvider):
         """
         url = f"{self.ACHIEVEMENTS_URL}/users/xuid({xuid})/history/titles"
         resp = await self.client.session.get(
-            url, headers=self.HEADERS_GAME_PROGRESS, **kwargs
+            url,
+            headers=self.HEADERS_GAME_PROGRESS,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return RecentProgressResponse(**resp.json())

--- a/xbox/webapi/api/provider/people/__init__.py
+++ b/xbox/webapi/api/provider/people/__init__.py
@@ -21,7 +21,7 @@ class PeopleProvider(RateLimitedProvider):
     }
     SEPERATOR = ","
 
-    RATE_LIMITS = {"BURST": 10, "SUSTAIN": 30}
+    RATE_LIMITS = {"burst": 10, "sustain": 30}
 
     def __init__(self, client):
         """

--- a/xbox/webapi/api/provider/people/__init__.py
+++ b/xbox/webapi/api/provider/people/__init__.py
@@ -3,7 +3,7 @@ People - Access friendlist from own profiles and others
 """
 from typing import List
 
-from xbox.webapi.api.provider.baseprovider import BaseProvider
+from xbox.webapi.api.provider.ratelimitedprovider import RateLimitedProvider
 from xbox.webapi.api.provider.people.models import (
     PeopleDecoration,
     PeopleResponse,
@@ -11,7 +11,7 @@ from xbox.webapi.api.provider.people.models import (
 )
 
 
-class PeopleProvider(BaseProvider):
+class PeopleProvider(RateLimitedProvider):
     SOCIAL_URL = "https://social.xboxlive.com"
     HEADERS_SOCIAL = {"x-xbl-contract-version": "2"}
     PEOPLE_URL = "https://peoplehub.xboxlive.com"
@@ -20,6 +20,8 @@ class PeopleProvider(BaseProvider):
         "Accept-Language": "overwrite in __init__",
     }
     SEPERATOR = ","
+
+    RATE_LIMITS = {"BURST": 10, "SUSTAIN": 30}
 
     def __init__(self, client):
         """

--- a/xbox/webapi/api/provider/people/__init__.py
+++ b/xbox/webapi/api/provider/people/__init__.py
@@ -53,7 +53,9 @@ class PeopleProvider(RateLimitedProvider):
         decoration = self.SEPERATOR.join(decoration_fields)
 
         url = f"{self.PEOPLE_URL}/users/me/people/social/decoration/{decoration}"
-        resp = await self.client.session.get(url, headers=self._headers, **kwargs)
+        resp = await self.client.session.get(
+            url, headers=self._headers, rate_limits=self.rate_limit_read, **kwargs
+        )
         resp.raise_for_status()
         return PeopleResponse(**resp.json())
 

--- a/xbox/webapi/api/provider/people/__init__.py
+++ b/xbox/webapi/api/provider/people/__init__.py
@@ -21,6 +21,7 @@ class PeopleProvider(RateLimitedProvider):
     }
     SEPERATOR = ","
 
+    # NOTE: Rate Limits are noted for social.xboxlive.com ONLY
     RATE_LIMITS = {"burst": 10, "sustain": 30}
 
     def __init__(self, client):
@@ -53,9 +54,7 @@ class PeopleProvider(RateLimitedProvider):
         decoration = self.SEPERATOR.join(decoration_fields)
 
         url = f"{self.PEOPLE_URL}/users/me/people/social/decoration/{decoration}"
-        resp = await self.client.session.get(
-            url, headers=self._headers, rate_limits=self.rate_limit_read, **kwargs
-        )
+        resp = await self.client.session.get(url, headers=self._headers, **kwargs)
         resp.raise_for_status()
         return PeopleResponse(**resp.json())
 
@@ -133,7 +132,9 @@ class PeopleProvider(RateLimitedProvider):
             :class:`PeopleSummaryResponse`: People Summary Response
         """
         url = self.SOCIAL_URL + "/users/me/summary"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL, **kwargs)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_SOCIAL, rate_limits=self.rate_limit_read, **kwargs
+        )
         resp.raise_for_status()
         return PeopleSummaryResponse(**resp.json())
 
@@ -150,7 +151,9 @@ class PeopleProvider(RateLimitedProvider):
             :class:`PeopleSummaryResponse`: People Summary Response
         """
         url = self.SOCIAL_URL + f"/users/xuid({xuid})/summary"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL, **kwargs)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_SOCIAL, rate_limits=self.rate_limit_read, **kwargs
+        )
         resp.raise_for_status()
         return PeopleSummaryResponse(**resp.json())
 
@@ -167,6 +170,8 @@ class PeopleProvider(RateLimitedProvider):
             :class:`PeopleSummaryResponse`: People Summary Response
         """
         url = self.SOCIAL_URL + f"/users/gt({gamertag})/summary"
-        resp = await self.client.session.get(url, headers=self.HEADERS_SOCIAL, **kwargs)
+        resp = await self.client.session.get(
+            url, headers=self.HEADERS_SOCIAL, rate_limits=self.rate_limit_read, **kwargs
+        )
         resp.raise_for_status()
         return PeopleSummaryResponse(**resp.json())

--- a/xbox/webapi/api/provider/profile/__init__.py
+++ b/xbox/webapi/api/provider/profile/__init__.py
@@ -5,14 +5,16 @@ Get Userprofiles by XUID or Gamertag
 """
 from typing import List
 
-from xbox.webapi.api.provider.baseprovider import BaseProvider
+from xbox.webapi.api.provider.ratelimitedprovider import RateLimitedProvider
 from xbox.webapi.api.provider.profile.models import ProfileResponse, ProfileSettings
 
 
-class ProfileProvider(BaseProvider):
+class ProfileProvider(RateLimitedProvider):
     PROFILE_URL = "https://profile.xboxlive.com"
     HEADERS_PROFILE = {"x-xbl-contract-version": "3"}
     SEPARATOR = ","
+
+    RATE_LIMITS = {"burst": 10, "sustain": 30}
 
     async def get_profiles(self, xuid_list: List[str], **kwargs) -> ProfileResponse:
         """
@@ -45,7 +47,11 @@ class ProfileProvider(BaseProvider):
         }
         url = self.PROFILE_URL + "/users/batch/profile/settings"
         resp = await self.client.session.post(
-            url, json=post_data, headers=self.HEADERS_PROFILE, **kwargs
+            url,
+            json=post_data,
+            headers=self.HEADERS_PROFILE,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return ProfileResponse(**resp.json())
@@ -83,7 +89,11 @@ class ProfileProvider(BaseProvider):
             )
         }
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_PROFILE, **kwargs
+            url,
+            params=params,
+            headers=self.HEADERS_PROFILE,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return ProfileResponse(**resp.json())
@@ -121,7 +131,11 @@ class ProfileProvider(BaseProvider):
             )
         }
         resp = await self.client.session.get(
-            url, params=params, headers=self.HEADERS_PROFILE, **kwargs
+            url,
+            params=params,
+            headers=self.HEADERS_PROFILE,
+            rate_limits=self.rate_limit_read,
+            **kwargs,
         )
         resp.raise_for_status()
         return ProfileResponse(**resp.json())

--- a/xbox/webapi/api/provider/ratelimitedprovider.py
+++ b/xbox/webapi/api/provider/ratelimitedprovider.py
@@ -6,7 +6,8 @@ Subclassed by providers with rate limit support
 
 from typing import Union
 from xbox.webapi.api.provider.baseprovider import BaseProvider
-from xbox.webapi.common.ratelimits.models import ParsedRateLimit, TimePeriod
+from xbox.webapi.common.ratelimits.models import LimitType, ParsedRateLimit, TimePeriod
+from xbox.webapi.common.ratelimits import CombinedRateLimit
 
 
 class RateLimitedProvider(BaseProvider):
@@ -19,20 +20,21 @@ class RateLimitedProvider(BaseProvider):
         Args:
             client (:class:`XboxLiveClient`): Instance of XboxLiveClient
         """
-        # [commented out for testing] super().__init__(client)
-        print(self.RATE_LIMITS)
+        super().__init__(client)
 
-        # Parse the rate limit dict
+        # Retrieve burst and sustain from the dict
         burst_key = self.RATE_LIMITS["burst"]
         sustain_key = self.RATE_LIMITS["sustain"]
 
+        # Parse the rate limit dict values
         burst_rate_limits = self.__parse_rate_limit_key(burst_key, TimePeriod.BURST)
-        sustain_rate_liits = self.__parse_rate_limit_key(
+        sustain_rate_limits = self.__parse_rate_limit_key(
             sustain_key, TimePeriod.SUSTAIN
         )
 
-        print(burst_rate_limits)
-        print(sustain_rate_liits)
+        # Instanciate CombinedRateLimits for read and write respectively
+        CombinedRateLimit(burst_rate_limits, sustain_rate_limits, type=LimitType.READ)
+        CombinedRateLimit(burst_rate_limits, sustain_rate_limits, type=LimitType.WRITE)
 
     def __parse_rate_limit_key(
         self, key: Union[int, dict[str, int]], period: TimePeriod

--- a/xbox/webapi/api/provider/ratelimitedprovider.py
+++ b/xbox/webapi/api/provider/ratelimitedprovider.py
@@ -1,0 +1,45 @@
+"""
+RateLimitedProvider
+
+Subclassed by providers with rate limit support
+"""
+
+from typing import Union
+from xbox.webapi.api.provider.baseprovider import BaseProvider
+from xbox.webapi.common.ratelimits.models import ParsedRateLimit
+
+
+class RateLimitedProvider(BaseProvider):
+    RATE_LIMITS: dict[str, Union[int, dict[str, int]]]
+
+    def __init__(self, client):
+        """
+        Initialize Baseclass
+
+        Args:
+            client (:class:`XboxLiveClient`): Instance of XboxLiveClient
+        """
+        # [commented out for testing] super().__init__(client)
+        print(self.RATE_LIMITS)
+
+        # Parse the rate limit dict
+        burst_key = self.RATE_LIMITS["burst"]
+        sustain_key = self.RATE_LIMITS["sustain"]
+
+        burst_rate_limits = self.__parse_rate_limit_key(burst_key)
+        sustain_rate_liits = self.__parse_rate_limit_key(sustain_key)
+
+        print(burst_rate_limits)
+        print(sustain_rate_liits)
+
+    def __parse_rate_limit_key(
+        self, key: Union[int, dict[str, int]]
+    ) -> ParsedRateLimit:
+        key_type = type(key)
+        if key_type == int:
+            return ParsedRateLimit(read=key, write=key)
+        elif key_type == dict:
+            # TODO: schema here?
+            # Since the key-value pairs match we can just pass the dict to the model
+            return ParsedRateLimit(**key)
+            # return ParsedRateLimit(read=key["read"], write=key["write"])

--- a/xbox/webapi/api/provider/ratelimitedprovider.py
+++ b/xbox/webapi/api/provider/ratelimitedprovider.py
@@ -4,14 +4,15 @@ RateLimitedProvider
 Subclassed by providers with rate limit support
 """
 
-from typing import Union
+from typing import Union, Dict
 from xbox.webapi.api.provider.baseprovider import BaseProvider
 from xbox.webapi.common.ratelimits.models import LimitType, ParsedRateLimit, TimePeriod
 from xbox.webapi.common.ratelimits import CombinedRateLimit
 
 
 class RateLimitedProvider(BaseProvider):
-    RATE_LIMITS: dict[str, Union[int, dict[str, int]]]
+    # dict -> Dict (typing.dict) https://stackoverflow.com/a/63460173
+    RATE_LIMITS: Dict[str, Union[int, Dict[str, int]]]
 
     def __init__(self, client):
         """
@@ -41,7 +42,7 @@ class RateLimitedProvider(BaseProvider):
         )
 
     def __parse_rate_limit_key(
-        self, key: Union[int, dict[str, int]], period: TimePeriod
+        self, key: Union[int, Dict[str, int]], period: TimePeriod
     ) -> ParsedRateLimit:
         key_type = type(key)
         if key_type == int:

--- a/xbox/webapi/api/provider/ratelimitedprovider.py
+++ b/xbox/webapi/api/provider/ratelimitedprovider.py
@@ -6,7 +6,7 @@ Subclassed by providers with rate limit support
 
 from typing import Union
 from xbox.webapi.api.provider.baseprovider import BaseProvider
-from xbox.webapi.common.ratelimits.models import ParsedRateLimit
+from xbox.webapi.common.ratelimits.models import ParsedRateLimit, TimePeriod
 
 
 class RateLimitedProvider(BaseProvider):
@@ -26,20 +26,22 @@ class RateLimitedProvider(BaseProvider):
         burst_key = self.RATE_LIMITS["burst"]
         sustain_key = self.RATE_LIMITS["sustain"]
 
-        burst_rate_limits = self.__parse_rate_limit_key(burst_key)
-        sustain_rate_liits = self.__parse_rate_limit_key(sustain_key)
+        burst_rate_limits = self.__parse_rate_limit_key(burst_key, TimePeriod.BURST)
+        sustain_rate_liits = self.__parse_rate_limit_key(
+            sustain_key, TimePeriod.SUSTAIN
+        )
 
         print(burst_rate_limits)
         print(sustain_rate_liits)
 
     def __parse_rate_limit_key(
-        self, key: Union[int, dict[str, int]]
+        self, key: Union[int, dict[str, int]], period: TimePeriod
     ) -> ParsedRateLimit:
         key_type = type(key)
         if key_type == int:
-            return ParsedRateLimit(read=key, write=key)
+            return ParsedRateLimit(read=key, write=key, period=period)
         elif key_type == dict:
             # TODO: schema here?
             # Since the key-value pairs match we can just pass the dict to the model
-            return ParsedRateLimit(**key)
+            return ParsedRateLimit(**key, period=period)
             # return ParsedRateLimit(read=key["read"], write=key["write"])

--- a/xbox/webapi/api/provider/ratelimitedprovider.py
+++ b/xbox/webapi/api/provider/ratelimitedprovider.py
@@ -33,8 +33,12 @@ class RateLimitedProvider(BaseProvider):
         )
 
         # Instanciate CombinedRateLimits for read and write respectively
-        CombinedRateLimit(burst_rate_limits, sustain_rate_limits, type=LimitType.READ)
-        CombinedRateLimit(burst_rate_limits, sustain_rate_limits, type=LimitType.WRITE)
+        self.rate_limit_read = CombinedRateLimit(
+            burst_rate_limits, sustain_rate_limits, type=LimitType.READ
+        )
+        self.rate_limit_write = CombinedRateLimit(
+            burst_rate_limits, sustain_rate_limits, type=LimitType.WRITE
+        )
 
     def __parse_rate_limit_key(
         self, key: Union[int, dict[str, int]], period: TimePeriod

--- a/xbox/webapi/common/exceptions.py
+++ b/xbox/webapi/common/exceptions.py
@@ -3,6 +3,9 @@ Special Exception subclasses
 """
 
 
+from xbox.webapi.common.ratelimits import RateLimit
+
+
 class XboxException(Exception):
     """Base exception for all Xbox exceptions to subclass"""
 
@@ -46,3 +49,10 @@ class NotFoundException(XboxException):
     """Any exception raised due to a resource being missing will subclass this"""
 
     pass
+
+
+class RateLimitExceededException(XboxException):
+    def __init__(self, message, rate_limit: RateLimit):
+        self.message = message
+        self.rate_limit = rate_limit
+        self.try_again_in = rate_limit.get_reset_after()

--- a/xbox/webapi/common/rate_limits.py
+++ b/xbox/webapi/common/rate_limits.py
@@ -20,8 +20,9 @@ class IncrementResult(BaseModel):
 
 
 class RateLimit:
-    def __init__(self, time_period: TimePeriod, limit: int):
+    def __init__(self, time_period: TimePeriod, type: LimitType, limit: int):
         self.__time_period = time_period
+        self.__type = type
         self.__limit = limit
 
         self.__exceeded: bool = False
@@ -31,6 +32,9 @@ class RateLimit:
 
     def get_time_period(self) -> "TimePeriod":
         return self.__time_period
+    
+    def get_limit_type(self) -> "LimitType":
+        return self.__type
 
     def get_reset_after(self) -> Union[datetime, None]:
         return self.__reset_after

--- a/xbox/webapi/common/rate_limits.py
+++ b/xbox/webapi/common/rate_limits.py
@@ -1,0 +1,62 @@
+from enum import Enum
+from datetime import datetime, timedelta
+from typing import Union
+from pydantic import BaseModel
+
+
+class TimePeriod(Enum):
+    BURST = 15
+    SUSTAIN = 300  # 5 minutes (300s)
+
+
+class LimitType(Enum):
+    WRITE = 0
+    READ = 1
+
+
+class IncrementResult(BaseModel):
+    counter: int
+    exceeded: bool
+
+
+class RateLimit:
+    def __init__(self, time_period: TimePeriod, limit: int):
+        self.__time_period = time_period
+        self.__limit = limit
+
+        self.__exceeded: bool = False
+        self.__counter = 0
+        # No requests so far, so reset_after is None.
+        self.__reset_after: Union[datetime, None] = None
+
+    def get_time_period(self) -> "TimePeriod":
+        return self.__time_period
+
+    def get_reset_after(self) -> Union[datetime, None]:
+        return self.__reset_after
+
+    def is_exceeded(self) -> bool:
+        self.__reset_counter_if_required()
+        return self.__exceeded
+
+    def increment(self) -> IncrementResult:
+        self.__reset_counter_if_required()
+        self.__counter += 1
+        self.__check_if_exceeded()
+        return IncrementResult(counter=self.__counter, exceeded=self.__exceeded)
+
+    # Should be called after every inc of the counter
+    def __check_if_exceeded(self):
+        if not self.__exceeded:
+            if self.__counter >= self.__limit:
+                self.__exceeded = True
+                self.__reset_after = datetime.now() + timedelta(
+                    seconds=self.get_time_period().value
+                )
+
+    def __reset_counter_if_required(self):
+        if self.__reset_after is not None and self.__exceeded:
+            if self.__reset_after < datetime.now():
+                self.__exceeded = False
+                self.__counter = 0
+                self.__reset_after = None

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -3,26 +3,8 @@ from typing import Union
 
 from xbox.webapi.common.ratelimits.models import TimePeriod, LimitType, IncrementResult
 
-from abc import ABCMeta, abstractmethod
 
-
-class RateLimit(metaclass=ABCMeta):
-    @abstractmethod
-    def get_time_period(self) -> "TimePeriod":
-        pass
-
-    @abstractmethod
-    def get_reset_after(self) -> Union[datetime, None]:
-        pass
-
-    def is_exceeded(self) -> bool:
-        pass
-
-    def increment(self) -> IncrementResult:
-        pass
-
-
-class SingleRateLimit(RateLimit):
+class SingleRateLimit:
     def __init__(self, time_period: TimePeriod, type: LimitType, limit: int):
         self.__time_period = time_period
         self.__type = type

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -271,11 +271,7 @@ class CombinedRateLimit(RateLimit):
             result = limit.increment()
             results.append(result)
 
-        # SPEC: Which counter should be picked here?
-        # For now, let's pick the *higher* counter
-        # (should incrementResult even include the counter?)
-        results[1].counter = 5
-
+        # SPEC: Let's pick the *higher* counter
         # By default, sorted() returns in ascending order, so let's set reverse=True
         # This means that the result with the highest counter will be the first element.
         results_sorted = sorted(results, key=lambda i: i.counter, reverse=True)

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -4,7 +4,7 @@ from typing import Union
 from xbox.webapi.common.ratelimits.models import TimePeriod, LimitType, IncrementResult
 
 
-class RateLimit:
+class SingleRateLimit:
     def __init__(self, time_period: TimePeriod, type: LimitType, limit: int):
         self.__time_period = time_period
         self.__type = type

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -97,7 +97,7 @@ class SingleRateLimit(RateLimit):
         )
 
 
-class CombinedRateLimit:
+class CombinedRateLimit(RateLimit):
     def __init__(self, *parsed_limits: ParsedRateLimit, type: LimitType):
         # *parsed_limits is a tuple
 

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -1,22 +1,7 @@
-from enum import Enum
 from datetime import datetime, timedelta
 from typing import Union
-from pydantic import BaseModel
 
-
-class TimePeriod(Enum):
-    BURST = 15
-    SUSTAIN = 300  # 5 minutes (300s)
-
-
-class LimitType(Enum):
-    WRITE = 0
-    READ = 1
-
-
-class IncrementResult(BaseModel):
-    counter: int
-    exceeded: bool
+from xbox.webapi.common.ratelimits.models import TimePeriod, LimitType, IncrementResult
 
 
 class RateLimit:
@@ -32,7 +17,7 @@ class RateLimit:
 
     def get_time_period(self) -> "TimePeriod":
         return self.__time_period
-    
+
     def get_limit_type(self) -> "LimitType":
         return self.__type
 

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -20,9 +20,11 @@ class RateLimit(metaclass=ABCMeta):
     def get_reset_after(self) -> Union[datetime, None]:
         pass
 
+    @abstractmethod
     def is_exceeded(self) -> bool:
         pass
 
+    @abstractmethod
     def increment(self) -> IncrementResult:
         pass
 

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Union
+from typing import Union, List
 
 from xbox.webapi.common.ratelimits.models import (
     ParsedRateLimit,
@@ -173,10 +173,12 @@ class CombinedRateLimit(RateLimit):
         # dates_valid has no elements, return None
         return None
 
-    def get_limits(self) -> list[SingleRateLimit]:
+    # list -> List (typing.List) https://stackoverflow.com/a/63460173
+    def get_limits(self) -> List[SingleRateLimit]:
         return self.__limits
 
-    def get_limits_by_period(self, period: TimePeriod) -> list[SingleRateLimit]:
+    # list -> List (typing.List) https://stackoverflow.com/a/63460173
+    def get_limits_by_period(self, period: TimePeriod) -> List[SingleRateLimit]:
         # Filter the list for the given LimitType
         matches = filter(lambda limit: limit.get_time_period() == period, self.__limits)
         # Convert the filter object to a list and return it

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -13,10 +13,6 @@ from abc import ABCMeta, abstractmethod
 
 class RateLimit(metaclass=ABCMeta):
     @abstractmethod
-    def get_time_period(self) -> "TimePeriod":
-        pass
-
-    @abstractmethod
     def get_reset_after(self) -> Union[datetime, None]:
         pass
 

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -154,3 +154,27 @@ class CombinedRateLimit:
 
         # Return True if any variable in list is True
         return True in is_exceeded_list
+
+    def increment(self) -> IncrementResult:
+        # Increment each limit
+        results: list[IncrementResult] = []
+        for limit in self.__limits:
+            result = limit.increment()
+            results.append(result)
+
+        # SPEC: Which counter should be picked here?
+        # For now, let's pick the *higher* counter
+        # (should incrementResult even include the counter?)
+        results[1].counter = 5
+
+        # By default, sorted() returns in ascending order, so let's set reverse=True
+        # This means that the result with the highest counter will be the first element.
+        results_sorted = sorted(results, key=lambda i: i.counter, reverse=True)
+
+        # Create an instance of IncrementResult and return it.
+        return IncrementResult(
+            counter=results_sorted[
+                0
+            ].counter,  # Use the highest counter (sorted in descending order)
+            exceeded=self.is_exceeded(),  # Call self.is_exceeded (True if any limit has been exceeded, a-la an OR gate.)
+        )

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -100,11 +100,12 @@ class CombinedRateLimit:
         self.__limits: list[SingleRateLimit] = []
 
         for limit in parsed_limits:
+            # Use the type param (enum LimitType) to determine which limit to select
             limit_num = limit.read if type == LimitType.READ else limit.write
-            print(
-                "Found %s limit of %i (%s)" % (limit.period.name, limit_num, type.name)
-            )
-            self.__limits.append(SingleRateLimit(limit.period, type, limit_num))
+
+            # Create a new instance of SingleRateLimit and append it to the limits array.
+            srl = SingleRateLimit(limit.period, type, limit_num)
+            self.__limits.append(srl)
 
         # DEBUG: print them
         for i in self.__limits:

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -46,6 +46,9 @@ class SingleRateLimit(RateLimit):
     def get_time_period(self) -> "TimePeriod":
         return self.__time_period
 
+    def get_limit(self) -> int:
+        return self.__limit
+
     def get_limit_type(self) -> "LimitType":
         return self.__type
 

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -113,3 +113,44 @@ class CombinedRateLimit:
                 "Added limit of type %s, limit %s, and limit %i"
                 % (i.get_limit_type(), i.get_time_period(), i._SingleRateLimit__limit)
             )
+
+    def get_reset_after(self) -> Union[datetime, None]:
+        # Map self.__limits to (limit).get_reset_after()
+        dates_map = map(lambda limit: limit.get_reset_after(), self.__limits)
+
+        # Convert the map object to a list
+        dates = list(dates_map)
+
+        # Construct a new list with only elements of instance datetime
+        # (Effectively filtering out any None elements)
+        dates_valid = [elem for elem in dates if type(elem) == datetime]
+
+        # If dates_valid has any elements, return the one with the *later* timestamp.
+        if len(dates_valid) != 0:
+            dates_valid[0].isoformat
+            print(
+                "Valid dates BEFORE sorting: %s"
+                % list(map(lambda i: i.isoformat(), dates_valid))
+            )
+            # By default dates are sorted with the earliest date first.
+            # We will set reverse=True so that the first element is the later date.
+            dates_valid.sort(reverse=True)
+
+            print(
+                "Valid dates AFTER sorting:  %s"
+                % list(map(lambda i: i.isoformat(), dates_valid))
+            )
+
+            # Return the datetime object.
+            return dates_valid[0]
+
+        # dates_valid has no elements, return None
+        return None
+
+    def is_exceeded(self) -> bool:
+        # Map self.__limits to (limit).is_exceeded()
+        is_exceeded_map = map(lambda limit: limit.is_exceeded(), self.__limits)
+        is_exceeded_list = list(is_exceeded_map)
+
+        # Return True if any variable in list is True
+        return True in is_exceeded_list

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -4,7 +4,7 @@ from typing import Union
 from xbox.webapi.common.ratelimits.models import TimePeriod, LimitType, IncrementResult
 
 
-class SingleRateLimit:
+class RateLimit:
     def __init__(self, time_period: TimePeriod, type: LimitType, limit: int):
         self.__time_period = time_period
         self.__type = type

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -170,6 +170,15 @@ class CombinedRateLimit(RateLimit):
         # dates_valid has no elements, return None
         return None
 
+    def get_limits(self) -> list[SingleRateLimit]:
+        return self.__limits
+
+    def get_limits_by_period(self, period: TimePeriod) -> list[SingleRateLimit]:
+        # Filter the list for the given LimitType
+        matches = filter(lambda limit: limit.get_time_period() == period, self.__limits)
+        # Convert the filter object to a list and return it
+        return list(matches)
+
     def is_exceeded(self) -> bool:
         # Map self.__limits to (limit).is_exceeded()
         is_exceeded_map = map(lambda limit: limit.is_exceeded(), self.__limits)

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -238,6 +238,8 @@ class CombinedRateLimit(RateLimit):
     def is_exceeded(self) -> bool:
         """
         This function returns `True` if **any** rate limit has been exceeded.
+        
+        It behaves like an OR logic gate.
         """
 
         # Map self.__limits to (limit).is_exceeded()
@@ -264,5 +266,5 @@ class CombinedRateLimit(RateLimit):
             counter=results_sorted[
                 0
             ].counter,  # Use the highest counter (sorted in descending order)
-            exceeded=self.is_exceeded(),  # Call self.is_exceeded (True if any limit has been exceeded, a-la an OR gate.)
+            exceeded=self.is_exceeded(),  # Call self.is_exceeded (True if any limit has been exceeded, like an OR gate.)
         )

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -3,8 +3,26 @@ from typing import Union
 
 from xbox.webapi.common.ratelimits.models import TimePeriod, LimitType, IncrementResult
 
+from abc import ABCMeta, abstractmethod
 
-class SingleRateLimit:
+
+class RateLimit(metaclass=ABCMeta):
+    @abstractmethod
+    def get_time_period(self) -> "TimePeriod":
+        pass
+
+    @abstractmethod
+    def get_reset_after(self) -> Union[datetime, None]:
+        pass
+
+    def is_exceeded(self) -> bool:
+        pass
+
+    def increment(self) -> IncrementResult:
+        pass
+
+
+class SingleRateLimit(RateLimit):
     def __init__(self, time_period: TimePeriod, type: LimitType, limit: int):
         self.__time_period = time_period
         self.__type = type

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -167,13 +167,6 @@ class CombinedRateLimit(RateLimit):
             srl = SingleRateLimit(limit.period, type, limit_num)
             self.__limits.append(srl)
 
-        # DEBUG: print them
-        for i in self.__limits:
-            print(
-                "Added limit of type %s, limit %s, and limit %i"
-                % (i.get_limit_type(), i.get_time_period(), i._SingleRateLimit__limit)
-            )
-
     def get_counter(self) -> int:
         """
         This function returns the request counter with the **highest** value.
@@ -221,19 +214,9 @@ class CombinedRateLimit(RateLimit):
         # If dates_valid has any elements, return the one with the *later* timestamp.
         # This means that if two or more limits have been exceeded, we wait for both to have reset (by returning the later timestamp)
         if len(dates_valid) != 0:
-            dates_valid[0].isoformat
-            print(
-                "Valid dates BEFORE sorting: %s"
-                % list(map(lambda i: i.isoformat(), dates_valid))
-            )
             # By default dates are sorted with the earliest date first.
             # We will set reverse=True so that the first element is the later date.
             dates_valid.sort(reverse=True)
-
-            print(
-                "Valid dates AFTER sorting:  %s"
-                % list(map(lambda i: i.isoformat(), dates_valid))
-            )
 
             # Return the datetime object.
             return dates_valid[0]

--- a/xbox/webapi/common/ratelimits/__init__.py
+++ b/xbox/webapi/common/ratelimits/__init__.py
@@ -13,6 +13,10 @@ from abc import ABCMeta, abstractmethod
 
 class RateLimit(metaclass=ABCMeta):
     @abstractmethod
+    def get_counter(self) -> int:
+        pass
+
+    @abstractmethod
     def get_reset_after(self) -> Union[datetime, None]:
         pass
 
@@ -35,6 +39,9 @@ class SingleRateLimit(RateLimit):
         self.__counter = 0
         # No requests so far, so reset_after is None.
         self.__reset_after: Union[datetime, None] = None
+
+    def get_counter(self) -> int:
+        return self.__counter
 
     def get_time_period(self) -> "TimePeriod":
         return self.__time_period
@@ -111,6 +118,18 @@ class CombinedRateLimit:
                 "Added limit of type %s, limit %s, and limit %i"
                 % (i.get_limit_type(), i.get_time_period(), i._SingleRateLimit__limit)
             )
+
+    def get_counter(self) -> int:
+        # Map self.__limits to (limit).get_counter()
+        counter_map = map(lambda limit: limit.get_counter(), self.__limits)
+        counters = list(counter_map)
+
+        # Sort the counters list by value
+        # reverse=True to get highest first
+        counters.sort(reverse=True)
+
+        # Return the highest value
+        return counters[0]
 
     def get_reset_after(self) -> Union[datetime, None]:
         # Map self.__limits to (limit).get_reset_after()

--- a/xbox/webapi/common/ratelimits/models.py
+++ b/xbox/webapi/common/ratelimits/models.py
@@ -2,16 +2,6 @@ from enum import Enum
 from pydantic import BaseModel
 
 
-class IncrementResult(BaseModel):
-    counter: int
-    exceeded: bool
-
-
-class ParsedRateLimit(BaseModel):
-    read: int
-    write: int
-
-
 class TimePeriod(Enum):
     BURST = 15  # 15 seconds
     SUSTAIN = 300  # 5 minutes (300s)
@@ -20,3 +10,14 @@ class TimePeriod(Enum):
 class LimitType(Enum):
     WRITE = 0
     READ = 1
+
+
+class IncrementResult(BaseModel):
+    counter: int
+    exceeded: bool
+
+
+class ParsedRateLimit(BaseModel):
+    read: int
+    write: int
+    period: TimePeriod

--- a/xbox/webapi/common/ratelimits/models.py
+++ b/xbox/webapi/common/ratelimits/models.py
@@ -1,0 +1,17 @@
+from enum import Enum
+from pydantic import BaseModel
+
+
+class IncrementResult(BaseModel):
+    counter: int
+    exceeded: bool
+
+
+class TimePeriod(Enum):
+    BURST = 15  # 15 seconds
+    SUSTAIN = 300  # 5 minutes (300s)
+
+
+class LimitType(Enum):
+    WRITE = 0
+    READ = 1

--- a/xbox/webapi/common/ratelimits/models.py
+++ b/xbox/webapi/common/ratelimits/models.py
@@ -7,6 +7,11 @@ class IncrementResult(BaseModel):
     exceeded: bool
 
 
+class ParsedRateLimit(BaseModel):
+    read: int
+    write: int
+
+
 class TimePeriod(Enum):
     BURST = 15  # 15 seconds
     SUSTAIN = 300  # 5 minutes (300s)


### PR DESCRIPTION
I think this is more of a proof-of-concept at the moment.

## To-Do

- [ ] Add `429` handling?
  _Would it be worth logging/otherwise storing times when rate limited requests still have 429s? Would indicate where we would need to change things._

### Docs
- [x] Add docstrings (properly document everything)

### Tests
- [ ] Limits
  - [x] Burst only
  - [x] Sustain only (reaches burst multiple times, waits for it to reset)
  - [ ] Burst and sustain limits exceeded at the same time
  - [ ] A test with sufficient lifecycle where rate limits are reset

~~- [ ] Sorting and filtering~~
  > Testing python behaviour is probably not necessary.
  