### PR TITLE
Add Nexus(Xbox) key to InputKeyType class

### DIFF
--- a/xbox/webapi/api/provider/smartglass/models.py
+++ b/xbox/webapi/api/provider/smartglass/models.py
@@ -180,6 +180,7 @@ class InputKeyType(str, Enum):
     Down = "Down"
     Left = "Left"
     Right = "Right"
+    Nexus = "Nexus"
 
 
 class GuideTab(str, Enum):


### PR DESCRIPTION
Apparently the Xbox web api does support sending Nexus(Xbox) key commands to consoles. But I can’t send the command through the Xbox Home Assistant integration. And I figured it’s probably because it’s not there in this class. I’m not sure why it’s not there but I added it anyway. 