### PR TITLE
Allow passing an SSLContext instead of creating a new one.

### DIFF
--- a/xbox/webapi/common/signed_session.py
+++ b/xbox/webapi/common/signed_session.py
@@ -3,14 +3,16 @@ Signed Session
 A wrapper around httpx' AsyncClient which transparently calculates the "Signature" header.
 """
 
+from ssl import SSLContext
 import httpx
 
 from xbox.webapi.common.request_signer import RequestSigner
 
 
 class SignedSession(httpx.AsyncClient):
-    def __init__(self, request_signer=None):
-        super().__init__()
+    def __init__(self, request_signer=None, ssl_context: SSLContext=None):
+        super().__init__(verify=ssl_context if ssl_context is not None else True)
+
         self.request_signer = request_signer or RequestSigner()
 
     @classmethod

--- a/xbox/webapi/common/signed_session.py
+++ b/xbox/webapi/common/signed_session.py
@@ -3,9 +3,9 @@ Signed Session
 A wrapper around httpx' AsyncClient which transparently calculates the "Signature" header.
 """
 
-from ssl import SSLContext
 import httpx
 
+from ssl import SSLContext
 from xbox.webapi.common.request_signer import RequestSigner
 
 


### PR DESCRIPTION
This change is to fix https://github.com/home-assistant/core/issues/133965 due to creating an SSLContext that does blocking IO. This adds an optional parameter to `SignedSession` to allow passing in an existing context.